### PR TITLE
duty-25.05.22: Bump docker base images versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ekidd/rust-musl-builder:1.57.0 AS builder
+FROM nwtgck/rust-musl-builder:1.60.0 AS builder
 
 COPY src src
 COPY Cargo.toml Cargo.toml
@@ -8,7 +8,7 @@ COPY api.ts api.ts
 RUN sudo chown -R rust:rust /home/rust && \
     cargo build --release
 
-FROM alpine:3.14
+FROM alpine:3.16
 
 ENV LOAD_DIR=/usr/local/bin/
 


### PR DESCRIPTION
# Task
Base image to build environment env on the first stage is outdated and hasn't still been updated to rust 1.60 by image maintainer. So, some of new build can not be compiled.

## Changes
1. change maintainer for `rust-musl-builder-1.60` base image (seems as frequently-updated account), was tested.
2. bump `alpine` as well

## Author
Sigh-off-by: Vasilii Zyabkin <zyabkin@soramitsu.co.jp>