### PR TITLE
feat!: gather telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
 ]
@@ -592,6 +614,12 @@ dependencies = [
  "inout",
  "zeroize",
 ]
+
+[[package]]
+name = "circular-buffer"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bdce1da528cadbac4654b5632bfcd8c6c63e25b1d42cea919a95958790b51d"
 
 [[package]]
 name = "clap"
@@ -923,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -962,6 +990,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1101,9 +1150,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1208,7 +1257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.5",
+ "miniz_oxide 0.8.7",
 ]
 
 [[package]]
@@ -1526,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.14.11"
+version = "0.14.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11365144ef93082f3403471dbaa94cfe4b5e72743bdb9560719a251d439f4cee"
+checksum = "8dc2c844c4cf141884678cabef736fd91dd73068b9146e6f004ba1a0457944b6"
 dependencies = [
  "bitflags",
  "bstr",
@@ -1749,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.14"
+version = "0.10.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40f12bb65a8299be0cfb90fe718e3be236b7a94b434877012980863a883a99f"
+checksum = "f910668e2f6b2a55ff35a1f04df88a1a049f7b868507f4cbeeaa220eaba7be87"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -1840,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.10.11"
+version = "0.10.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84dae13271f4313f8d60a166bf27e54c968c7c33e2ffd31c48cafe5da649875"
+checksum = "47aeb0f13de9ef2f3033f5ff218de30f44db827ac9f1286f9ef050aacddd5888"
 dependencies = [
  "bitflags",
  "gix-path",
@@ -1945,7 +1994,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2370,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -2412,11 +2461,10 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroha"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "attohttpc",
  "base64",
- "derive_more",
+ "derive_more 0.99.19",
  "displaydoc",
  "error-stack",
  "eyre",
@@ -2449,10 +2497,9 @@ dependencies = [
 [[package]]
 name = "iroha_config"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "cfg-if",
- "derive_more",
+ "derive_more 0.99.19",
  "displaydoc",
  "error-stack",
  "hex",
@@ -2476,9 +2523,8 @@ dependencies = [
 [[package]]
 name = "iroha_config_base"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.19",
  "drop_bomb",
  "error-stack",
  "iroha_config_base_derive",
@@ -2493,7 +2539,6 @@ dependencies = [
 [[package]]
 name = "iroha_config_base_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2506,14 +2551,13 @@ dependencies = [
 [[package]]
 name = "iroha_crypto"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "aead",
  "arrayref",
  "blake2",
  "chacha20poly1305",
  "curve25519-dalek",
- "derive_more",
+ "derive_more 0.99.19",
  "digest",
  "displaydoc",
  "ed25519-dalek",
@@ -2542,11 +2586,10 @@ dependencies = [
 [[package]]
 name = "iroha_data_model"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "base64",
  "derive-where",
- "derive_more",
+ "derive_more 0.99.19",
  "displaydoc",
  "getset",
  "iroha_crypto",
@@ -2567,7 +2610,6 @@ dependencies = [
 [[package]]
 name = "iroha_data_model_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2580,7 +2622,6 @@ dependencies = [
 [[package]]
 name = "iroha_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2593,9 +2634,8 @@ dependencies = [
 [[package]]
 name = "iroha_executor_data_model"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.19",
  "iroha_data_model",
  "iroha_executor_data_model_derive",
  "iroha_schema",
@@ -2606,7 +2646,6 @@ dependencies = [
 [[package]]
 name = "iroha_executor_data_model_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "manyhow",
  "proc-macro2",
@@ -2618,17 +2657,20 @@ dependencies = [
 name = "iroha_explorer"
 version = "0.2.0"
 dependencies = [
+ "async-stream",
  "axum",
  "base64",
  "chrono",
+ "circular-buffer",
  "clap",
+ "derive_more 2.0.1",
  "expect-test",
  "eyre",
+ "futures-util",
  "http",
  "insta",
  "iroha",
  "iroha_crypto",
- "iroha_telemetry",
  "nonzero_ext",
  "parity-scale-codec",
  "reqwest",
@@ -2649,7 +2691,6 @@ dependencies = [
 [[package]]
 name = "iroha_futures"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "iroha_config",
  "iroha_futures_derive",
@@ -2665,7 +2706,6 @@ dependencies = [
 [[package]]
 name = "iroha_futures_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -2677,10 +2717,9 @@ dependencies = [
 [[package]]
 name = "iroha_logger"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "color-eyre",
- "derive_more",
+ "derive_more 0.99.19",
  "iroha_config",
  "iroha_data_model",
  "serde_json",
@@ -2696,7 +2735,6 @@ dependencies = [
 [[package]]
 name = "iroha_macro"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "iroha_derive",
 ]
@@ -2704,7 +2742,6 @@ dependencies = [
 [[package]]
 name = "iroha_macro_utils"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "darling",
  "drop_bomb",
@@ -2717,9 +2754,8 @@ dependencies = [
 [[package]]
 name = "iroha_numeric"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.19",
  "displaydoc",
  "iroha_schema",
  "parity-scale-codec",
@@ -2732,9 +2768,8 @@ dependencies = [
 [[package]]
 name = "iroha_primitives"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.19",
  "displaydoc",
  "iroha_macro",
  "iroha_numeric",
@@ -2753,7 +2788,6 @@ dependencies = [
 [[package]]
 name = "iroha_primitives_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "iroha_numeric",
  "manyhow",
@@ -2765,7 +2799,6 @@ dependencies = [
 [[package]]
 name = "iroha_schema"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "iroha_schema_derive",
  "serde",
@@ -2774,7 +2807,6 @@ dependencies = [
 [[package]]
 name = "iroha_schema_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2787,7 +2819,6 @@ dependencies = [
 [[package]]
 name = "iroha_telemetry"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2796,6 +2827,7 @@ dependencies = [
  "iroha_config",
  "iroha_futures",
  "iroha_logger",
+ "iroha_schema",
  "iroha_telemetry_derive",
  "parity-scale-codec",
  "prometheus",
@@ -2812,7 +2844,6 @@ dependencies = [
 [[package]]
 name = "iroha_telemetry_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -2824,7 +2855,6 @@ dependencies = [
 [[package]]
 name = "iroha_torii_const"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "iroha_primitives",
 ]
@@ -2832,7 +2862,6 @@ dependencies = [
 [[package]]
 name = "iroha_version"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "iroha_macro",
  "iroha_version_derive",
@@ -2845,7 +2874,6 @@ dependencies = [
 [[package]]
 name = "iroha_version_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger/iroha.git?rev=22d84e7ba64df81c63b2006ced467f6be5752833#22d84e7ba64df81c63b2006ced467f6be5752833"
 dependencies = [
  "darling",
  "manyhow",
@@ -3093,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
 dependencies = [
  "adler2",
 ]
@@ -3239,9 +3267,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3271,9 +3299,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",
@@ -3625,9 +3653,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
 ]
@@ -4074,7 +4102,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4203,9 +4231,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 dependencies = [
  "serde",
 ]
@@ -4270,7 +4298,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.2",
  "hashlink",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "log",
  "memchr",
  "once_cell",
@@ -4704,9 +4732,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4829,7 +4857,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5112,7 +5140,7 @@ version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_json",
  "utoipa-gen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.15",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,6 +2467,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,6 +2682,7 @@ version = "0.2.0"
 dependencies = [
  "async-stream",
  "axum",
+ "backoff",
  "base64",
  "chrono",
  "circular-buffer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,6 +2484,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroha"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "attohttpc",
  "base64",
@@ -2520,6 +2521,7 @@ dependencies = [
 [[package]]
 name = "iroha_config"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "cfg-if",
  "derive_more 0.99.19",
@@ -2546,6 +2548,7 @@ dependencies = [
 [[package]]
 name = "iroha_config_base"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "derive_more 0.99.19",
  "drop_bomb",
@@ -2562,6 +2565,7 @@ dependencies = [
 [[package]]
 name = "iroha_config_base_derive"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2574,6 +2578,7 @@ dependencies = [
 [[package]]
 name = "iroha_crypto"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "aead",
  "arrayref",
@@ -2609,6 +2614,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "base64",
  "derive-where",
@@ -2633,6 +2639,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model_derive"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2645,6 +2652,7 @@ dependencies = [
 [[package]]
 name = "iroha_derive"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2657,6 +2665,7 @@ dependencies = [
 [[package]]
 name = "iroha_executor_data_model"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "derive_more 0.99.19",
  "iroha_data_model",
@@ -2669,6 +2678,7 @@ dependencies = [
 [[package]]
 name = "iroha_executor_data_model_derive"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "manyhow",
  "proc-macro2",
@@ -2715,6 +2725,7 @@ dependencies = [
 [[package]]
 name = "iroha_futures"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "iroha_config",
  "iroha_futures_derive",
@@ -2730,6 +2741,7 @@ dependencies = [
 [[package]]
 name = "iroha_futures_derive"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -2741,6 +2753,7 @@ dependencies = [
 [[package]]
 name = "iroha_logger"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "color-eyre",
  "derive_more 0.99.19",
@@ -2759,6 +2772,7 @@ dependencies = [
 [[package]]
 name = "iroha_macro"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "iroha_derive",
 ]
@@ -2766,6 +2780,7 @@ dependencies = [
 [[package]]
 name = "iroha_macro_utils"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "darling",
  "drop_bomb",
@@ -2778,6 +2793,7 @@ dependencies = [
 [[package]]
 name = "iroha_numeric"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "derive_more 0.99.19",
  "displaydoc",
@@ -2792,6 +2808,7 @@ dependencies = [
 [[package]]
 name = "iroha_primitives"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "derive_more 0.99.19",
  "displaydoc",
@@ -2812,6 +2829,7 @@ dependencies = [
 [[package]]
 name = "iroha_primitives_derive"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "iroha_numeric",
  "manyhow",
@@ -2823,6 +2841,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "iroha_schema_derive",
  "serde",
@@ -2831,6 +2850,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema_derive"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2843,6 +2863,7 @@ dependencies = [
 [[package]]
 name = "iroha_telemetry"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2868,6 +2889,7 @@ dependencies = [
 [[package]]
 name = "iroha_telemetry_derive"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -2879,6 +2901,7 @@ dependencies = [
 [[package]]
 name = "iroha_torii_const"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "iroha_primitives",
 ]
@@ -2886,6 +2909,7 @@ dependencies = [
 [[package]]
 name = "iroha_version"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "iroha_macro",
  "iroha_version_derive",
@@ -2898,6 +2922,7 @@ dependencies = [
 [[package]]
 name = "iroha_version_derive"
 version = "2.0.0-rc.1.0"
+source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
 dependencies = [
  "darling",
  "manyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,7 +2678,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_explorer"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,7 +2484,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroha"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "attohttpc",
  "base64",
@@ -2504,7 +2504,6 @@ dependencies = [
  "iroha_telemetry",
  "iroha_torii_const",
  "iroha_version",
- "nonzero_ext",
  "parity-scale-codec",
  "rand",
  "serde",
@@ -2521,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "iroha_config"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "cfg-if",
  "derive_more 0.99.19",
@@ -2548,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "iroha_config_base"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "derive_more 0.99.19",
  "drop_bomb",
@@ -2565,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "iroha_config_base_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2578,7 +2577,7 @@ dependencies = [
 [[package]]
 name = "iroha_crypto"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "aead",
  "arrayref",
@@ -2614,7 +2613,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "base64",
  "derive-where",
@@ -2639,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "iroha_data_model_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2652,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "iroha_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2665,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "iroha_executor_data_model"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "derive_more 0.99.19",
  "iroha_data_model",
@@ -2678,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "iroha_executor_data_model_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "manyhow",
  "proc-macro2",
@@ -2725,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "iroha_futures"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "iroha_config",
  "iroha_futures_derive",
@@ -2741,7 +2740,7 @@ dependencies = [
 [[package]]
 name = "iroha_futures_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -2753,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "iroha_logger"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "color-eyre",
  "derive_more 0.99.19",
@@ -2772,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "iroha_macro"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "iroha_derive",
 ]
@@ -2780,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "iroha_macro_utils"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "darling",
  "drop_bomb",
@@ -2793,7 +2792,7 @@ dependencies = [
 [[package]]
 name = "iroha_numeric"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "derive_more 0.99.19",
  "displaydoc",
@@ -2808,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "iroha_primitives"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "derive_more 0.99.19",
  "displaydoc",
@@ -2829,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "iroha_primitives_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "iroha_numeric",
  "manyhow",
@@ -2841,7 +2840,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "iroha_schema_derive",
  "serde",
@@ -2850,7 +2849,7 @@ dependencies = [
 [[package]]
 name = "iroha_schema_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2863,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "iroha_telemetry"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2889,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "iroha_telemetry_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -2901,7 +2900,7 @@ dependencies = [
 [[package]]
 name = "iroha_torii_const"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "iroha_primitives",
 ]
@@ -2909,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "iroha_version"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "iroha_macro",
  "iroha_version_derive",
@@ -2922,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "iroha_version_derive"
 version = "2.0.0-rc.1.0"
-source = "git+https://github.com/0x009922/iroha.git?branch=commit-time-metrics#41517a0c81c996c9db57c6e22022fed3c22cf393"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
 dependencies = [
  "darling",
  "manyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.3.0"
 edition = "2021"
 
 [dependencies]
-iroha = { git = "https://github.com/0x009922/iroha.git", branch = "commit-time-metrics" }
+iroha = { git = "https://github.com/hyperledger-iroha/iroha.git", rev = "3f039a3f51fdb16207a481dd2bedb8d17df86186" }
 
 tracing = "0.1.32"
 tracing-subscriber = { version = "0.3.10", features = ["env-filter"] }
@@ -37,7 +37,7 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 [dev-dependencies]
 insta = { version = "1.42.2", features = ["json", "csv"] }
 expect-test = "1.5.0"
-iroha_crypto = { git = "https://github.com/0x009922/iroha.git", branch = "commit-time-metrics", features = ["rand"] }
+iroha_crypto = { git = "https://github.com/hyperledger-iroha/iroha.git", rev = "3f039a3f51fdb16207a481dd2bedb8d17df86186", features = ["rand"] }
 tokio = { version = "1", features = ["process"] }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,13 @@ futures-util = "0.3.30"
 async-stream = "0.3.6"
 derive_more = { version = "2.0.1", features = ["display", "from_str"] }
 circular-buffer = "1.1.0"
+reqwest = { version = "0.12.15", features = ["json"] }
+backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 
 [dev-dependencies]
 insta = { version = "1.42.2", features = ["json", "csv"] }
 expect-test = "1.5.0"
 iroha_crypto = { path = "../iroha/crates/iroha_crypto", features = ["rand"] }
 tokio = { version = "1", features = ["process"] }
-reqwest = { version = "0.12.15", features = ["json"] }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,7 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-# FIXME: `iroha` must expose `Status` struct
-iroha_telemetry = { git = "https://github.com/hyperledger/iroha.git", rev = "22d84e7ba64df81c63b2006ced467f6be5752833" }
-iroha = { git = "https://github.com/hyperledger/iroha.git", rev = "22d84e7ba64df81c63b2006ced467f6be5752833" }
+iroha = { path = "../iroha/crates/iroha" }
 
 tracing = "0.1.32"
 tracing-subscriber = { version = "0.3.10", features = ["env-filter"] }
@@ -29,11 +27,15 @@ sqlx = { version = "0.8.0", features = ["sqlite", "runtime-tokio", "chrono"] }
 eyre = "0.6.12"
 parity-scale-codec = "3.7.4"
 base64 = "0.22.1"
+futures-util = "0.3.30"
+async-stream = "0.3.6"
+derive_more = { version = "2.0.1", features = ["display", "from_str"] }
+circular-buffer = "1.1.0"
 
 [dev-dependencies]
 insta = { version = "1.42.2", features = ["json", "csv"] }
 expect-test = "1.5.0"
-iroha_crypto = { git = "https://github.com/hyperledger/iroha.git", rev = "22d84e7ba64df81c63b2006ced467f6be5752833", features = ["rand"] }
+iroha_crypto = { path = "../iroha/crates/iroha_crypto", features = ["rand"] }
 tokio = { version = "1", features = ["process"] }
 reqwest = { version = "0.12.15", features = ["json"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iroha_explorer"
 description = "Backend API of Iroha 2 Explorer"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.3.0"
 edition = "2021"
 
 [dependencies]
-iroha = { path = "../iroha/crates/iroha" }
+iroha = { git = "https://github.com/0x009922/iroha.git", branch = "commit-time-metrics" }
 
 tracing = "0.1.32"
 tracing-subscriber = { version = "0.3.10", features = ["env-filter"] }
@@ -37,7 +37,7 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 [dev-dependencies]
 insta = { version = "1.42.2", features = ["json", "csv"] }
 expect-test = "1.5.0"
-iroha_crypto = { path = "../iroha/crates/iroha_crypto", features = ["rand"] }
+iroha_crypto = { git = "https://github.com/0x009922/iroha.git", branch = "commit-time-metrics", features = ["rand"] }
 tokio = { version = "1", features = ["process"] }
 
 

--- a/src/database_update.rs
+++ b/src/database_update.rs
@@ -42,7 +42,7 @@ impl DatabaseUpdateLoop {
     }
 
     async fn attempt(&mut self) -> eyre::Result<()> {
-        let Some(metrics) = self.telemetry.single_peer(self.client.torii_url()).await? else {
+        let Some(metrics) = self.telemetry.single_peer(&self.client.torii_url()).await? else {
             tracing::warn!("Skipping database update - peer metrics are not available");
             return Ok(());
         };

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -455,7 +455,7 @@ pub async fn telemetry_live(
     Ok(sse::Sse::new(stream).keep_alive(sse::KeepAlive::default()))
 }
 
-pub async fn peers_index(
+pub async fn telemetry_peers_info(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<schema::PeerInfo>>, AppError> {
     let data = state.telemetry.peers_info().await?;
@@ -479,9 +479,9 @@ pub fn router(repo: Repo, telemetry: Telemetry) -> Router {
         .route("/transactions", get(transactions_index))
         .route("/transactions/{:hash}", get(transactions_show))
         .route("/instructions", get(instructions_index))
-        .route("/peers", get(peers_index))
         .route("/telemetry/network", get(telemetry_network))
         .route("/telemetry/peers", get(telemetry_peers))
+        .route("/telemetry/peers-info", get(telemetry_peers_info))
         .route("/telemetry/live", get(telemetry_live))
         .with_state(AppState { repo, telemetry })
 }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -69,6 +69,7 @@ struct DomainsIndexFilter {
 #[utoipa::path(
     get,
     path = "/domains",
+    tags = ["Blockchain entities"],
     responses(
         (status = 200, description = "OK", body = Page<schema::Domain>)
     ),
@@ -92,7 +93,9 @@ async fn domains_index(
 }
 
 /// Find a domain
-#[utoipa::path(get, path = "/domains/{id}", responses(
+#[utoipa::path(get, path = "/domains/{id}",
+    tags = ["Blockchain entities"],
+    responses(
     (status = 200, description = "Domain Found", body = schema::Domain),
     (status = 404, description = "Domain Not Found")
 ), params(("id" = schema::DomainId, description = "Domain ID", example = "genesis")))]
@@ -109,6 +112,7 @@ async fn domains_show(
 #[utoipa::path(
     get,
     path = "/blocks",
+    tags = ["Blockchain entities"],
     responses(
         (status = 200, description = "OK", body = [schema::Block]),
     ),
@@ -130,6 +134,7 @@ async fn blocks_index(
 #[utoipa::path(
     get,
     path = "/blocks/{height_or_hash}",
+    tags = ["Blockchain entities"],
     params(
         ("height_or_hash", description = "Height or hash of the block", example = "12")
     ),
@@ -167,6 +172,7 @@ struct TransactionsIndexFilter {
 #[utoipa::path(
     get,
     path = "/transactions",
+    tags = ["Blockchain entities"],
     params(schema::PaginationQueryParams, TransactionsIndexFilter),
     responses(
         (status = 200, description = "OK", body = Page<schema::TransactionBase>)
@@ -191,7 +197,9 @@ async fn transactions_index(
 }
 
 /// Find a transaction by its hash
-#[utoipa::path(get, path = "/transactions/{hash}", params(
+#[utoipa::path(get, path = "/transactions/{hash}",
+    tags = ["Blockchain entities"],
+    params(
     ("hash" = schema::Hash, description = "Hash of the transaction", example = "9FC55BD948D0CDE0838F6D86FA069A258F033156EE9ACEF5A5018BC9589473F3")
 ), responses(
     (status = 200, description = "Transaction Found", body = schema::TransactionDetailed),
@@ -217,6 +225,7 @@ struct AccountsIndexFilter {
 #[utoipa::path(
     get,
     path = "/accounts",
+    tags = ["Blockchain entities"],
     params(schema::PaginationQueryParams, AccountsIndexFilter),
     responses(
         (status = 200, description = "OK", body = [schema::Account])
@@ -240,7 +249,9 @@ async fn accounts_index(
 }
 
 /// Find an account
-#[utoipa::path(get, path = "/accounts/{id}", responses(
+#[utoipa::path(get, path = "/accounts/{id}",
+    tags = ["Blockchain entities"],
+    responses(
     (status = 200, description = "Found", body = schema::Account),
     (status = 404, description = "Not Found")
 ), params(("id" = schema::AccountId, description = "Account ID")))]
@@ -263,6 +274,7 @@ struct AssetDefinitionsIndexFilter {
 #[utoipa::path(
     get,
     path = "/assets-definitions",
+    tags = ["Blockchain entities"],
     params(schema::PaginationQueryParams, AssetDefinitionsIndexFilter),
     responses(
         (status = 200, description = "OK", body = [schema::AssetDefinition])
@@ -286,7 +298,9 @@ async fn assets_definitions_index(
 }
 
 /// Find an asset definition
-#[utoipa::path(get, path = "/assets-definitions/{id}", responses(
+#[utoipa::path(get, path = "/assets-definitions/{id}",
+    tags = ["Blockchain entities"],
+    responses(
     (status = 200, description = "Found", body = schema::AssetDefinition),
     (status = 404, description = "Not Found")
 ), params(("id" = schema::AssetDefinitionId, description = "Asset Definition ID")))]
@@ -310,6 +324,7 @@ struct AssetsIndexFilter {
 #[utoipa::path(
     get,
     path = "/assets",
+    tags = ["Blockchain entities"],
     params(schema::PaginationQueryParams, AssetsIndexFilter),
     responses(
         (status = 200, description = "OK", body = [schema::Asset])
@@ -333,7 +348,9 @@ async fn assets_index(
 }
 
 /// Find an asset
-#[utoipa::path(get, path = "/assets/{id}", responses(
+#[utoipa::path(get, path = "/assets/{id}",
+    tags = ["Blockchain entities"],
+    responses(
     (status = 200, description = "Found", body = schema::Asset),
     (status = 404, description = "Not Found")
 ), params(("id" = schema::AssetId, description = "Asset ID")))]
@@ -349,6 +366,7 @@ async fn assets_show(
 #[utoipa::path(
     get,
     path = "/nfts",
+    tags = ["Blockchain entities"],
     params(schema::PaginationQueryParams, AssetDefinitionsIndexFilter),
     responses(
         (status = 200, description = "OK", body = [schema::Nft])
@@ -372,7 +390,9 @@ async fn nfts_index(
 }
 
 /// Find an asset definition
-#[utoipa::path(get, path = "/nfts/{id}", responses(
+#[utoipa::path(get, path = "/nfts/{id}",
+    tags = ["Blockchain entities"],
+    responses(
     (status = 200, description = "Found", body = schema::Nft),
     (status = 404, description = "Not Found")
 ), params(("id" = schema::NftId, description = "Asset Definition ID")))]
@@ -401,6 +421,7 @@ struct InstructionsIndexFilter {
 #[utoipa::path(
     get,
     path = "/instructions",
+    tags = ["Blockchain entities"],
     params(PaginationQueryParams, InstructionsIndexFilter),
     responses(
         (status = 200, description = "OK", body = [schema::Instruction])
@@ -426,6 +447,16 @@ async fn instructions_index(
     Ok(Json(items))
 }
 
+/// Get overall network telemetry
+#[utoipa::path(
+    get,
+    path = "/network",
+    tags = ["Telemetry"],
+    responses(
+        (status = 200, description = "OK", body = schema::NetworkStatus),
+        (status = 503, description = "Explorer has not yet gathered sufficient data to serve this request")
+    )
+)]
 pub async fn telemetry_network(
     State(state): State<AppState>,
 ) -> Result<Json<schema::NetworkStatus>, AppError> {
@@ -437,6 +468,15 @@ pub async fn telemetry_network(
     Ok(Json(data))
 }
 
+/// Get telemetry for all connected peers
+#[utoipa::path(
+    get,
+    path = "/peers",
+    tags = ["Telemetry"],
+    responses(
+        (status = 200, description = "OK", body = [schema::PeerStatus])
+    )
+)]
 pub async fn telemetry_peers(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<schema::PeerStatus>>, AppError> {
@@ -444,6 +484,20 @@ pub async fn telemetry_peers(
     Ok(Json(data))
 }
 
+/// Receive live updates of telemetry
+#[utoipa::path(
+    get,
+    path = "/live",
+    tags = ["Telemetry"],
+    responses(
+        (
+            status = 200,
+            description = "OK, stream is ready",
+            content_type = "text/event-stream",
+            body = schema::TelemetryStreamMessage
+        )
+    )
+)]
 pub async fn telemetry_live(
     State(state): State<AppState>,
 ) -> Result<sse::Sse<impl Stream<Item = Result<sse::Event, axum::Error>>>, AppError> {
@@ -455,6 +509,15 @@ pub async fn telemetry_live(
     Ok(sse::Sse::new(stream).keep_alive(sse::KeepAlive::default()))
 }
 
+/// Get static telemetry information about peers
+#[utoipa::path(
+    get,
+    path = "/peers-info",
+    tags = ["Telemetry"],
+    responses(
+        (status = 200, description = "OK", body = [schema::PeerInfo])
+    )
+)]
 pub async fn telemetry_peers_info(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<schema::PeerInfo>>, AppError> {
@@ -488,21 +551,37 @@ pub fn router(repo: Repo, telemetry: Telemetry) -> Router {
 
 // TODO: add new paths
 #[derive(OpenApi)]
-#[openapi(paths(
-    accounts_index,
-    accounts_show,
-    assets_index,
-    assets_show,
-    nfts_index,
-    nfts_show,
-    assets_definitions_index,
-    assets_definitions_show,
-    domains_index,
-    domains_show,
-    blocks_index,
-    blocks_show,
-    transactions_index,
-    transactions_show,
-    instructions_index,
-))]
+#[openapi(
+    paths(
+        accounts_index,
+        accounts_show,
+        assets_index,
+        assets_show,
+        nfts_index,
+        nfts_show,
+        assets_definitions_index,
+        assets_definitions_show,
+        domains_index,
+        domains_show,
+        blocks_index,
+        blocks_show,
+        transactions_index,
+        transactions_show,
+        instructions_index,
+    ),
+    nest((path = "/telemetry", api = TelemetryApi)),
+    tags(
+        (name = "Blockchain entities", description = "Routes serving blockchain entities such as blocks, transactions, domains etc"),
+        (name = "Telemetry", description = "Routes serving network and peers telemetry data")
+    )
+)]
 pub struct Api;
+
+#[derive(OpenApi)]
+#[openapi(paths(
+    telemetry_network,
+    telemetry_peers,
+    telemetry_peers_info,
+    telemetry_live
+))]
+struct TelemetryApi;

--- a/src/iroha_client_wrap.rs
+++ b/src/iroha_client_wrap.rs
@@ -1,3 +1,4 @@
+use crate::schema::ToriiUrl;
 use iroha::client::Client;
 use iroha::crypto::KeyPair;
 use iroha::data_model::account::AccountId;
@@ -5,7 +6,6 @@ use iroha::data_model::ChainId;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
-use url::Url;
 
 #[derive(Debug, Clone)]
 pub struct ClientWrap(Arc<Client>);
@@ -19,11 +19,11 @@ impl Deref for ClientWrap {
 }
 
 impl ClientWrap {
-    pub fn new(authority: AccountId, key_pair: KeyPair, torii_url: Url) -> Self {
+    pub fn new(authority: AccountId, key_pair: KeyPair, torii_url: ToriiUrl) -> Self {
         Client::new(iroha::config::Config {
             account: authority,
             key_pair,
-            torii_api_url: torii_url,
+            torii_api_url: torii_url.0,
             basic_auth: None,
 
             // we only use queries, and these fields are unused
@@ -33,6 +33,10 @@ impl ClientWrap {
             transaction_ttl: Duration::from_secs(0),
         })
         .into()
+    }
+
+    pub fn torii_url(&self) -> &ToriiUrl {
+        todo!()
     }
 }
 

--- a/src/iroha_client_wrap.rs
+++ b/src/iroha_client_wrap.rs
@@ -35,8 +35,8 @@ impl ClientWrap {
         .into()
     }
 
-    pub fn torii_url(&self) -> &ToriiUrl {
-        todo!()
+    pub fn torii_url(&self) -> ToriiUrl {
+        ToriiUrl(self.torii_url.clone())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,7 +248,9 @@ async fn do_serve(repo: Repo, telemetry: Telemetry, args: ServeBaseArgs) {
 }
 
 /// Health check
-#[utoipa::path(get, path = "/api/health")]
+#[utoipa::path(get, path = "/api/health", tag = "Misc", responses(
+    (status = 200, description = "Explorer is up and running", content_type = "text/plain", example = json!("healthy"))
+))]
 async fn health_check() -> &'static str {
     "healthy"
 }
@@ -380,6 +382,12 @@ mod tests {
         )
         .await;
         ensure_status(&client, path("/api/v1/telemetry/peers"), StatusCode::OK).await;
+        ensure_status(
+            &client,
+            path("/api/v1/telemetry/peers-info"),
+            StatusCode::OK,
+        )
+        .await;
         ensure_status(&client, path("/api/v1/telemetry/live"), StatusCode::OK).await;
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,7 +311,7 @@ mod tests {
         let value: ArgToriiUrls = "http://iroha.tech/1,http://iroha.tech/2".parse().unwrap();
         assert_eq!(value.some(), "http://iroha.tech/1".parse().unwrap());
         assert_eq!(
-            value.all().into_iter().collect::<Vec<_>>(),
+            value.all().iter().collect::<Vec<_>>(),
             vec![
                 &"http://iroha.tech/1".parse::<ToriiUrl>().unwrap(),
                 &"http://iroha.tech/2".parse().unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,12 @@ mod endpoint;
 mod iroha_client_wrap;
 mod repo;
 mod schema;
+mod telemetry;
 mod util;
 
-use crate::endpoint::StatusProvider;
 use crate::iroha_client_wrap::ClientWrap;
 use crate::repo::{scan_iroha, Repo};
+use crate::telemetry::{Telemetry, TelemetryConfig};
 use axum::routing::get;
 use axum::{
     extract::{MatchedPath, Request},
@@ -19,16 +20,19 @@ use axum::{
 };
 use clap::Parser;
 use database_update::DatabaseUpdateLoop;
+use eyre::{eyre, Context};
 use iroha::crypto::{KeyPair, PrivateKey};
 use iroha::data_model::account::AccountId;
+use schema::ToriiUrl;
 use sqlx::sqlite::SqliteConnectOptions;
 use sqlx::{ConnectOptions, Connection};
+use std::collections::BTreeSet;
 use std::net::IpAddr;
 use std::path::PathBuf;
+use std::str::FromStr;
 use tokio::task::JoinSet;
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _};
-use url::Url;
 use utoipa::OpenApi;
 use utoipa_scalar::{Scalar, Servable};
 
@@ -51,32 +55,67 @@ pub enum Subcommand {
 }
 
 #[derive(Parser, Debug)]
-pub struct IrohaCredentialsArgs {
+pub struct IrohaArgs {
     /// Account ID in a form of `signatory@domain` on which behalf to perform Iroha Queries
     #[clap(long, env = "IROHA_EXPLORER_ACCOUNT")]
     pub account: AccountId,
     /// Multihash of the account's private key
     #[clap(long, env = "IROHA_EXPLORER_ACCOUNT_PRIVATE_KEY")]
     pub account_private_key: PrivateKey,
-    /// Iroha Torii URL
-    #[clap(long, env = "IROHA_EXPLORER_TORII_URL")]
-    pub torii_url: Url,
+    /// Iroha Torii URL(s), comma-separated list
+    ///
+    /// At least one is required.
+    #[clap(long, env = "IROHA_EXPLORER_TORII_URLS")]
+    pub torii_urls: ArgToriiUrls,
 }
 
-impl IrohaCredentialsArgs {
-    fn client(self) -> ClientWrap {
+impl IrohaArgs {
+    fn client(&self) -> ClientWrap {
         ClientWrap::new(
-            self.account,
-            KeyPair::from(self.account_private_key),
-            self.torii_url,
+            self.account.clone(),
+            KeyPair::from(self.account_private_key.clone()),
+            self.torii_urls.some(),
         )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ArgToriiUrls(BTreeSet<ToriiUrl>);
+
+impl FromStr for ArgToriiUrls {
+    type Err = eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let urls = s
+            .split(',')
+            .map(FromStr::from_str)
+            .collect::<Result<BTreeSet<ToriiUrl>, _>>()
+            .wrap_err("Cannot parse URL(s)")?;
+        if urls.is_empty() {
+            Err(eyre!("There should be at least one URL"))
+        } else {
+            Ok(Self(urls))
+        }
+    }
+}
+
+impl ArgToriiUrls {
+    fn some(&self) -> ToriiUrl {
+        self.0
+            .first()
+            .cloned()
+            .expect("there should be at least one")
+    }
+
+    fn all(&self) -> &BTreeSet<ToriiUrl> {
+        &self.0
     }
 }
 
 #[derive(Parser, Debug)]
 pub struct ScanArgs {
     #[command(flatten)]
-    creds: IrohaCredentialsArgs,
+    iroha: IrohaArgs,
     /// Path to `SQLite` database to scan Iroha to
     out_file: PathBuf,
 }
@@ -96,7 +135,7 @@ pub struct ServeArgs {
     #[command(flatten)]
     base: ServeBaseArgs,
     #[command(flatten)]
-    creds: IrohaCredentialsArgs,
+    iroha: IrohaArgs,
 }
 
 #[derive(OpenApi)]
@@ -107,7 +146,7 @@ pub struct ServeArgs {
 struct Api;
 
 #[cfg(debug_assertions)]
-const DEFAULT_LOG: &str = "iroha_explorer=debug,tower_http=debug,sqlx=debug";
+const DEFAULT_LOG: &str = "iroha_explorer=trace,tower_http=debug,sqlx=debug";
 #[cfg(not(debug_assertions))]
 const DEFAULT_LOG: &str = "info";
 
@@ -123,9 +162,6 @@ async fn main() {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    // let key_pair = KeyPair::from(args.account_private_key);
-    // let iroha_client = ClientWrap::new(args.account, key_pair, args.torii_url);
-
     match args.command {
         Subcommand::Serve(args) => serve(args).await,
         #[cfg(debug_assertions)]
@@ -136,18 +172,22 @@ async fn main() {
 
 async fn serve(args: ServeArgs) {
     let repo = Repo::new(None);
-    let client = args.creds.client();
+    let client = args.iroha.client();
 
     let mut set = JoinSet::<()>::new();
+    let (telemetry, telemetry_fut) = Telemetry::start(TelemetryConfig {
+        urls: args.iroha.torii_urls.all().clone(),
+    });
+    set.spawn(telemetry_fut);
     set.spawn({
         let repo = repo.clone();
-        let client = client.clone();
+        let tel = telemetry.clone();
         async move {
-            do_serve(repo, StatusProvider::Iroha(client), args.base).await;
+            do_serve(repo, tel, args.base).await;
         }
     });
     set.spawn(async move {
-        DatabaseUpdateLoop::new(repo, client).run().await;
+        DatabaseUpdateLoop::new(repo, client, telemetry).run().await;
     });
     set.join_all().await;
 }
@@ -159,18 +199,22 @@ async fn serve_test(args: ServeBaseArgs) {
     tracing::info!("test data is ready");
 
     let mut set = JoinSet::<()>::new();
+    let (telemetry, telemetry_fut) = Telemetry::start(TelemetryConfig {
+        urls: <_>::default(),
+    });
+    set.spawn(telemetry_fut);
     set.spawn(async move {
-        do_serve(repo.clone(), StatusProvider::None, args).await;
+        do_serve(repo.clone(), telemetry, args).await;
     });
     set.join_all().await;
 }
 
-async fn do_serve(repo: Repo, status_provider: StatusProvider, args: ServeBaseArgs) {
+async fn do_serve(repo: Repo, telemetry: Telemetry, args: ServeBaseArgs) {
     // TODO: handle endpoint panics
     let app = Router::new()
         .merge(Scalar::with_url("/api/docs", Api::openapi()))
         .route("/api/health", get(health_check))
-        .nest("/api/v1", endpoint::router(repo, status_provider))
+        .nest("/api/v1", endpoint::router(repo, telemetry))
         .layer(
             TraceLayer::new_for_http()
                 // Create our own span for the request and include the matched path. The matched
@@ -194,7 +238,7 @@ async fn do_serve(repo: Repo, status_provider: StatusProvider, args: ServeBaseAr
     let listener = tokio::net::TcpListener::bind((args.ip, args.port))
         .await
         .unwrap();
-    tracing::debug!("listening on http://{}", listener.local_addr().unwrap());
+    tracing::info!("listening on http://{}", listener.local_addr().unwrap());
 
     axum::serve(listener, app).await.unwrap()
 }
@@ -224,7 +268,7 @@ async fn scan(args: ScanArgs) -> eyre::Result<()> {
         .create_if_missing(true)
         .connect()
         .await?;
-    scan_iroha(&args.creds.client(), &mut conn).await?;
+    scan_iroha(&args.iroha.client(), &mut conn).await?;
     conn.close().await?;
     tracing::info!(?args.out_file, "written");
     Ok(())
@@ -243,6 +287,23 @@ mod tests {
     fn cli() {
         use clap::CommandFactory;
         Args::command().debug_assert();
+    }
+
+    #[test]
+    fn parse_torii_urls() {
+        let value: ArgToriiUrls = "http://iroha.tech/1,http://iroha.tech/2".parse().unwrap();
+        assert_eq!(value.some(), "http://iroha.tech/1".parse().unwrap());
+        assert_eq!(
+            value.all().into_iter().collect::<Vec<_>>(),
+            vec![
+                &"http://iroha.tech/1".parse::<ToriiUrl>().unwrap(),
+                &"http://iroha.tech/2".parse().unwrap(),
+            ]
+        );
+
+        let _ = ""
+            .parse::<ArgToriiUrls>()
+            .expect_err("should fail with nothing");
     }
 
     #[tokio::test]
@@ -303,7 +364,14 @@ mod tests {
             StatusCode::OK,
         )
         .await;
-        ensure_status(&client, path("/api/v1/status"), StatusCode::NOT_IMPLEMENTED).await;
+        ensure_status(
+            &client,
+            path("/api/v1/telemetry/network"),
+            StatusCode::SERVICE_UNAVAILABLE,
+        )
+        .await;
+        ensure_status(&client, path("/api/v1/telemetry/peers"), StatusCode::OK).await;
+        ensure_status(&client, path("/api/v1/telemetry/live"), StatusCode::OK).await;
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,6 +275,17 @@ async fn scan(args: ScanArgs) -> eyre::Result<()> {
 }
 
 #[cfg(test)]
+fn init_test_logger() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| DEFAULT_LOG.into()),
+        )
+        .with(tracing_subscriber::fmt::layer().pretty())
+        .init();
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use reqwest::StatusCode;
@@ -309,13 +320,7 @@ mod tests {
     #[tokio::test]
     async fn serve_test_ok() -> eyre::Result<()> {
         // Uncomment for troubleshooting
-        // tracing_subscriber::registry()
-        //     .with(
-        //         tracing_subscriber::EnvFilter::try_from_default_env()
-        //             .unwrap_or_else(|_| DEFAULT_LOG.into()),
-        //     )
-        //     .with(tracing_subscriber::fmt::layer())
-        //     .init();
+        // init_test_logger();
 
         spawn(serve_test(ServeBaseArgs {
             ip: "127.0.0.1".parse()?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,12 +154,16 @@ const DEFAULT_LOG: &str = "info";
 async fn main() {
     let args = Args::parse();
 
+    #[cfg(debug_assertions)]
+    let fmt_layer = tracing_subscriber::fmt::layer().pretty();
+    #[cfg(not(debug_assertions))]
+    let fmt_layer = tracing_subscriber::fmt::layer();
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| DEFAULT_LOG.into()),
         )
-        .with(tracing_subscriber::fmt::layer())
+        .with(fmt_layer)
         .init();
 
     match args.command {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -438,7 +438,7 @@ impl Repo {
             .await?)
     }
 
-    async fn acquire_conn(&self) -> MappedMutexGuard<'_, SqliteConnection> {
+    pub async fn acquire_conn(&self) -> MappedMutexGuard<'_, SqliteConnection> {
         loop {
             let guard = self.conn.lock().await;
             match MutexGuard::try_map(guard, Option::as_mut) {
@@ -836,14 +836,14 @@ impl<'a> PushCustom<'a> for SelectInstructions<'a> {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use insta::{assert_csv_snapshot, assert_debug_snapshot, assert_json_snapshot};
     use serde_json::json;
     use sqlx::types::JsonValue;
     use sqlx::{query, query_as, Connection};
 
-    async fn test_repo() -> Repo {
+    pub async fn test_repo() -> Repo {
         let mut conn = SqliteConnection::connect("sqlite::memory:").await.unwrap();
         query(include_str!("./repo/test_dump.sql"))
             .execute(&mut conn)

--- a/src/repo/from_iroha.rs
+++ b/src/repo/from_iroha.rs
@@ -269,6 +269,9 @@ mod tests {
     #[ignore]
     #[tokio::test]
     async fn create_test_dump() -> Result<()> {
+        // Uncomment for troubleshooting
+        // crate::init_test_logger();
+
         let db_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_dump_db.sqlite");
         let dump_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/repo/test_dump.sql");
 
@@ -290,14 +293,6 @@ mod tests {
             transaction_ttl: Duration::from_secs(300),
         });
         let client_wrap = ClientWrap::from(client.clone());
-
-        tracing_subscriber::registry()
-            .with(
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| "iroha_explorer=debug,sqlx=debug".into()),
-            )
-            .with(tracing_subscriber::fmt::layer())
-            .init();
 
         debug!("Filling Iroha...");
         spawn_blocking(move || fill_iroha(&client)).await??;

--- a/src/repo/from_iroha.rs
+++ b/src/repo/from_iroha.rs
@@ -248,8 +248,6 @@ mod tests {
     use sqlx::{ConnectOptions, Connection};
     use std::path::{Path, PathBuf};
     use std::time::Duration;
-    use tracing_subscriber::layer::SubscriberExt;
-    use tracing_subscriber::util::SubscriberInitExt;
 
     /// This function automates the creation of `test_dump.sql`, and is meant to be run manually.
     ///

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -814,7 +814,7 @@ pub struct NetworkStatus {
     pub domains: u32,
     /// Count of registered accounts
     pub accounts: u32,
-    /// Count of registered assets (definitions) and NFTs
+    /// Count of assets and NFTs
     pub assets: u32,
     /// Accepted transactions
     pub transactions_accepted: u32,
@@ -824,13 +824,13 @@ pub struct NetworkStatus {
     pub block: u32,
     /// Timestamp when the last block was created (not committed)
     pub block_created_at: TimeStamp,
-    /// Finalized block, the one that __cannot be reverted__ under normal network conditions
+    /// Finalized block, the one that __cannot be reverted__ under normal network conditions.
     ///
-    /// Might be not available if there are not enough metrics from peers
+    /// Might be not available if there are not enough metrics from peers.
     pub finalized_block: Option<u32>,
-    /// Average commit time among all peers during a certain observation period
+    /// Average commit time among all peers during a certain observation period.
     ///
-    /// Might be not available if there are not enough metrics from peers
+    /// Might be not available if there are not enough metrics from peers.
     pub avg_commit_time: Option<TimeDuration>,
     /// Average time between created blocks during a certain observation period
     pub avg_block_time: TimeDuration,
@@ -898,7 +898,7 @@ pub struct PeerInfo {
     pub config: Option<PeerConfig>,
     /// Location of the peer, if known
     pub location: Option<GeoLocation>,
-    /// List of peers it is connected to
+    /// Set of connected peers
     pub connected_peers: Option<BTreeSet<PublicKey>>,
 }
 
@@ -922,14 +922,20 @@ impl Ord for PeerInfo {
     }
 }
 
-// TODO: use config dto from iroha directly
+/// Peer configuration
 #[derive(Serialize, ToSchema, Clone, Debug)]
 pub struct PeerConfig {
+    /// Public key of the peer
     pub public_key: PublicKey,
+    /// Queue capacity
     pub queue_capacity: u32,
+    /// Block gossip batch size
     pub network_block_gossip_size: u32,
+    /// Block gossip period
     pub network_block_gossip_period: TimeDuration,
+    /// Transactions gossip batch size
     pub network_tx_gossip_size: u32,
+    /// Transactions gossip period
     pub network_tx_gossip_period: TimeDuration,
 }
 
@@ -950,19 +956,31 @@ impl From<iroha::ConfigGetDTO> for PeerConfig {
     }
 }
 
+/// Container for possible messages returned from the telemetry live updates stream.
+///
+/// Variants are distinguished by the `kind` tag.
 #[derive(Clone, Serialize, ToSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TelemetryStreamMessage {
+    /// First message, reflecting system metrics at the beginning of the connection.
+    ///
+    /// Sent immediately upon connection.
     First(TelemetryStreamFirstMessage),
+    /// Network status update
     NetworkStatus(NetworkStatus),
+    /// Peer status (i.e. dynamic metrics) update
     PeerStatus(PeerStatus),
+    /// Peer info (i.e. more static data) update
     PeerInfo(PeerInfo),
 }
 
 #[derive(Serialize, ToSchema, Clone)]
 pub struct TelemetryStreamFirstMessage {
+    /// Available peers info
     pub peers_info: BTreeSet<PeerInfo>,
+    /// Available peers status
     pub peers_status: BTreeSet<PeerStatus>,
+    /// Available network status
     pub network_status: Option<NetworkStatus>,
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -869,7 +869,15 @@ impl PartialEq for PeerStatus {
 
 impl PartialOrd for PeerStatus {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.url.partial_cmp(&other.url)
+        Some(self.cmp(other))
+    }
+}
+
+impl Eq for PeerStatus {}
+
+impl Ord for PeerStatus {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.url.cmp(&other.url)
     }
 }
 
@@ -892,6 +900,26 @@ pub struct PeerInfo {
     pub location: Option<GeoLocation>,
     /// List of peers it is connected to
     pub connected_peers: Option<BTreeSet<PublicKey>>,
+}
+
+impl PartialEq for PeerInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.url.eq(&other.url)
+    }
+}
+
+impl PartialOrd for PeerInfo {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Eq for PeerInfo {}
+
+impl Ord for PeerInfo {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.url.cmp(&other.url)
+    }
 }
 
 // TODO: use config dto from iroha directly
@@ -922,11 +950,20 @@ impl From<iroha::ConfigGetDTO> for PeerConfig {
     }
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, ToSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TelemetryStreamMessage {
+    First(TelemetryStreamFirstMessage),
     NetworkStatus(NetworkStatus),
     PeerStatus(PeerStatus),
     PeerInfo(PeerInfo),
+}
+
+#[derive(Serialize, ToSchema, Clone)]
+pub struct TelemetryStreamFirstMessage {
+    pub peers_info: BTreeSet<PeerInfo>,
+    pub peers_status: BTreeSet<PeerStatus>,
+    pub network_status: Option<NetworkStatus>,
 }
 
 /// Public key multihash

--- a/src/snapshots/iroha_explorer__telemetry__state_tests__empty.snap
+++ b/src/snapshots/iroha_explorer__telemetry__state_tests__empty.snap
@@ -6,6 +6,7 @@ expression: info
   {
     "url": "http://iroha.tech/0",
     "connected": false,
+    "telemetry_unsupported": false,
     "config": null,
     "location": null,
     "connected_peers": null
@@ -13,6 +14,7 @@ expression: info
   {
     "url": "http://iroha.tech/1",
     "connected": false,
+    "telemetry_unsupported": false,
     "config": null,
     "location": null,
     "connected_peers": null
@@ -20,6 +22,7 @@ expression: info
   {
     "url": "http://iroha.tech/2",
     "connected": false,
+    "telemetry_unsupported": false,
     "config": null,
     "location": null,
     "connected_peers": null
@@ -27,6 +30,7 @@ expression: info
   {
     "url": "http://iroha.tech/3",
     "connected": false,
+    "telemetry_unsupported": false,
     "config": null,
     "location": null,
     "connected_peers": null

--- a/src/snapshots/iroha_explorer__telemetry__state_tests__empty.snap
+++ b/src/snapshots/iroha_explorer__telemetry__state_tests__empty.snap
@@ -1,0 +1,34 @@
+---
+source: src/telemetry.rs
+expression: info
+---
+[
+  {
+    "url": "http://iroha.tech/0",
+    "connected": false,
+    "config": null,
+    "location": null,
+    "connected_peers": null
+  },
+  {
+    "url": "http://iroha.tech/1",
+    "connected": false,
+    "config": null,
+    "location": null,
+    "connected_peers": null
+  },
+  {
+    "url": "http://iroha.tech/2",
+    "connected": false,
+    "config": null,
+    "location": null,
+    "connected_peers": null
+  },
+  {
+    "url": "http://iroha.tech/3",
+    "connected": false,
+    "config": null,
+    "location": null,
+    "connected_peers": null
+  }
+]

--- a/src/snapshots/iroha_explorer__telemetry__state_tests__full_peer_update_cycle-2.snap
+++ b/src/snapshots/iroha_explorer__telemetry__state_tests__full_peer_update_cycle-2.snap
@@ -1,0 +1,18 @@
+---
+source: src/telemetry.rs
+expression: status
+---
+{
+  "url": "http://iroha.tech/test",
+  "block": 0,
+  "commit_time": {
+    "ms": 0
+  },
+  "avg_commit_time": {
+    "ms": 122
+  },
+  "queue_size": 0,
+  "uptime": {
+    "ms": 0
+  }
+}

--- a/src/snapshots/iroha_explorer__telemetry__state_tests__full_peer_update_cycle.snap
+++ b/src/snapshots/iroha_explorer__telemetry__state_tests__full_peer_update_cycle.snap
@@ -5,6 +5,7 @@ expression: info
 {
   "url": "http://iroha.tech/test",
   "connected": true,
+  "telemetry_unsupported": false,
   "config": {
     "public_key": "ed0120F6E4EF7509559C05F361B36CEB3473BE8A2D5A6A1903BC887261746FDBA36728",
     "queue_capacity": 65536,
@@ -18,8 +19,8 @@ expression: info
     }
   },
   "location": {
-    "lat": 55,
-    "long": 32,
+    "lat": 55.0,
+    "lon": 32.0,
     "country": "Wonderland",
     "city": "Makondo"
   },

--- a/src/snapshots/iroha_explorer__telemetry__state_tests__full_peer_update_cycle.snap
+++ b/src/snapshots/iroha_explorer__telemetry__state_tests__full_peer_update_cycle.snap
@@ -1,0 +1,30 @@
+---
+source: src/telemetry.rs
+expression: info
+---
+{
+  "url": "http://iroha.tech/test",
+  "connected": true,
+  "config": {
+    "public_key": "ed0120F6E4EF7509559C05F361B36CEB3473BE8A2D5A6A1903BC887261746FDBA36728",
+    "queue_capacity": 65536,
+    "network_block_gossip_size": 4,
+    "network_block_gossip_period": {
+      "ms": 10000
+    },
+    "network_tx_gossip_size": 500,
+    "network_tx_gossip_period": {
+      "ms": 1000
+    }
+  },
+  "location": {
+    "lat": 55,
+    "long": 32,
+    "country": "Wonderland",
+    "city": "Makondo"
+  },
+  "connected_peers": [
+    "ed0120C9B1EA0502ABE3B25F6A6C9687E22C1665D1AC5BBD98B02006FEFFE259820D44",
+    "ed0120F9C065A8E1A37AF6C4A6CDEE715DFD2E02D29BEE7B8AA9FF1AAE4D19F67A56E5"
+  ]
+}

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,792 @@
+pub mod blockchain;
+mod peer_monitor;
+
+use crate::schema::{
+    GeoLocation, NetworkStatus, PeerInfo, PeerStatus, TelemetryStreamMessage, ToriiUrl,
+};
+use async_stream::stream;
+use circular_buffer::CircularBuffer;
+use futures_util::stream::Stream;
+use iroha::client::ConfigGetDTO;
+use iroha::crypto::PublicKey;
+use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+use std::time::Duration;
+use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::task::JoinSet;
+
+pub struct TelemetryConfig {
+    /// List of Torii URLs to gather metrics from
+    pub urls: BTreeSet<ToriiUrl>,
+}
+
+#[derive(Clone)]
+pub struct Telemetry {
+    actor: mpsc::Sender<ActorMessage>,
+}
+
+impl Telemetry {
+    pub fn start(config: TelemetryConfig) -> (Self, impl Future<Output = ()> + Sized) {
+        let (actor, handle) = mpsc::channel(512);
+
+        #[cfg(debug_assertions)]
+        if config.urls.is_empty() {
+            tracing::warn!("No URLs provided to gather telemetry from")
+        }
+
+        let actor_clone = actor.clone();
+        let fut = async move {
+            let mut set = JoinSet::new();
+
+            set.spawn({
+                let urls = config.urls.clone();
+                async move {
+                    TelemetryActor::new(urls, handle).run().await;
+                    tracing::debug!("Actor terminated");
+                }
+            });
+
+            for url in config.urls {
+                let actor = actor_clone.clone();
+                let (mut recv, monitor_fut) = peer_monitor::run(url.clone());
+                set.spawn(monitor_fut);
+                set.spawn(async move {
+                    loop {
+                        match recv.recv().await {
+                            Ok(message) => {
+                                if let Err(err) = actor
+                                    .send(ActorMessage::HandlePeerMonitorUpdate(
+                                        url.clone(),
+                                        message,
+                                    ))
+                                    .await
+                                {
+                                    tracing::warn!(?err, "Actor is down");
+                                    break;
+                                };
+                            }
+                            Err(broadcast::error::RecvError::Lagged(amount)) => {
+                                tracing::warn!(%amount, "Peer monitor message receiver lagged");
+                            }
+                            Err(broadcast::error::RecvError::Closed) => break,
+                        }
+                    }
+                });
+            }
+
+            loop {
+                match set.join_next().await {
+                    Some(Ok(())) => {}
+                    Some(Err(err)) => {
+                        tracing::error!(?err, "Join error, aborting");
+                        panic!("not a recoverable error");
+                    }
+                    None => break,
+                }
+            }
+        };
+
+        (Self { actor }, fut)
+    }
+
+    pub async fn network(&self) -> eyre::Result<Option<NetworkStatus>> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.actor
+            .send(ActorMessage::GetNetworkStatus { reply: reply_tx })
+            .await?;
+        let reply = reply_rx.await?;
+        Ok(reply)
+    }
+
+    pub async fn peers(&self) -> eyre::Result<Vec<PeerStatus>> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.actor
+            .send(ActorMessage::GetPeersStatus { reply: reply_tx })
+            .await?;
+        let reply = reply_rx.await?;
+        Ok(reply)
+    }
+
+    pub async fn peers_info(&self) -> eyre::Result<Vec<PeerInfo>> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.actor
+            .send(ActorMessage::GetPeersInfo { reply: reply_tx })
+            .await?;
+        let reply = reply_rx.await?;
+        Ok(reply)
+    }
+
+    pub async fn live(&self) -> eyre::Result<impl Stream<Item = TelemetryStreamMessage>> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.actor
+            .send(ActorMessage::Stream { reply: reply_tx })
+            .await?;
+        let mut rx = reply_rx.await?;
+        let stream = stream! {
+            loop {
+                match rx.recv().await {
+                    Ok(data) => yield data,
+                    Err(broadcast::error::RecvError::Closed) => {
+                        tracing::error!("telemetry stopped streaming metrics, which is abnormal");
+                        break
+                    },
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        tracing::warn!(
+                            skipped_messages=skipped,
+                            "peers metrics stream lagged too far behind; \
+                             client might result in an inconsistent state; \
+                             continuing streaming nonetheless"
+                        );
+                    },
+
+                }
+            }
+        };
+        Ok(stream)
+    }
+
+    pub async fn single_peer(&self, url: &ToriiUrl) -> eyre::Result<Option<PeerStatus>> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.actor
+            .send(ActorMessage::GetSinglePeerStatus {
+                url: url.clone(),
+                reply: reply_tx,
+            })
+            .await?;
+        let reply = reply_rx.await?;
+        Ok(reply)
+    }
+
+    pub async fn update_blockchain_state(&self, state: blockchain::State) -> eyre::Result<()> {
+        self.actor
+            .send(ActorMessage::UpdateBlockchainState(state))
+            .await?;
+        Ok(())
+    }
+}
+
+enum ActorMessage {
+    HandlePeerMonitorUpdate(ToriiUrl, peer_monitor::Update),
+    UpdateBlockchainState(blockchain::State),
+    GetNetworkStatus {
+        reply: oneshot::Sender<Option<NetworkStatus>>,
+    },
+    GetPeersInfo {
+        reply: oneshot::Sender<Vec<PeerInfo>>,
+    },
+    GetPeersStatus {
+        reply: oneshot::Sender<Vec<PeerStatus>>,
+    },
+    GetSinglePeerStatus {
+        url: ToriiUrl,
+        reply: oneshot::Sender<Option<PeerStatus>>,
+    },
+    Stream {
+        reply: oneshot::Sender<broadcast::Receiver<TelemetryStreamMessage>>,
+    },
+}
+
+struct TelemetryActor {
+    state: State,
+    handle: mpsc::Receiver<ActorMessage>,
+    live: broadcast::Sender<TelemetryStreamMessage>,
+}
+
+impl TelemetryActor {
+    fn new(peers: BTreeSet<ToriiUrl>, handle: mpsc::Receiver<ActorMessage>) -> Self {
+        const CAPACITY: usize = 512;
+        let state = State::new(peers);
+        let (live_tx, _rx) = broadcast::channel(CAPACITY);
+        Self {
+            state,
+            handle,
+            live: live_tx,
+        }
+    }
+
+    async fn run(mut self) {
+        while let Some(message) = self.handle.recv().await {
+            match message {
+                ActorMessage::GetNetworkStatus { reply } => {
+                    let _: Result<_, _> = reply.send(self.state.network_status());
+                }
+                ActorMessage::GetPeersStatus { reply } => {
+                    let _: Result<_, _> = reply.send(self.state.peers_status().collect());
+                }
+                ActorMessage::GetPeersInfo { reply } => {
+                    let _: Result<_, _> = reply.send(self.state.peers_info().collect());
+                }
+                ActorMessage::GetSinglePeerStatus { url, reply } => {
+                    let _: Result<_, _> = reply.send(self.state.single_peer_status(&url));
+                }
+                ActorMessage::Stream { reply } => {
+                    let rx = self.live.subscribe();
+                    let _: Result<_, _> = reply.send(rx);
+                }
+                ActorMessage::UpdateBlockchainState(state) => {
+                    self.state.update_blockchain(state);
+                    let updated_status = self
+                        .state
+                        .network_status()
+                        .expect("must exist after update_blockchain() call");
+                    tracing::trace!("Broadcast live update of network status");
+                    let _: Result<_, _> = self
+                        .live
+                        .send(TelemetryStreamMessage::NetworkStatus(updated_status));
+                }
+                ActorMessage::HandlePeerMonitorUpdate(url, update) => {
+                    tracing::trace!(%url, ?update, "Peer update");
+                    match self.state.update_peer(&url, update) {
+                        Ok(segment) => {
+                            tracing::trace!(?segment, "Broadcast live update of peer");
+                            let _: Result<_, _> = self.live.send(segment.into());
+                        }
+                        Err(PeerNotFound) => {
+                            tracing::error!(%url, "Received peer update for an unknown peer");
+                        }
+                    }
+                }
+            }
+        }
+        tracing::debug!("Telemetry actor handle dropped, exiting");
+    }
+}
+
+struct State {
+    blockchain: Option<blockchain::State>,
+    peers: BTreeMap<ToriiUrl, PeerState>,
+}
+
+impl State {
+    fn new(peers: BTreeSet<ToriiUrl>) -> Self {
+        let peers = peers
+            .into_iter()
+            .map(|url| (url.clone(), PeerState::new(url)))
+            .collect();
+
+        Self {
+            blockchain: None,
+            peers,
+        }
+    }
+
+    /// Compute based on the supermajority rule - the block height by ⅔ nodes of the network
+    /// (see
+    /// [Fault Tolerance](https://hyperledger-iroha.github.io/iroha-2-docs/get-started/iroha-2.html#fault-tolerance)
+    /// article).
+    fn finalized_block(&self) -> Option<u32> {
+        let mut blocks: Vec<_> = self
+            .peers
+            .values()
+            .filter_map(|peer| peer.metrics.as_ref().map(|metrics| metrics.block))
+            .map(std::cmp::Reverse)
+            .collect();
+        blocks.sort_unstable();
+        let supermajority_index = self.peers.len() * 2 / 3;
+        let value = blocks[..].get(supermajority_index).map(|x| x.0);
+        value
+    }
+
+    fn avg_commit_time(&self) -> Option<Duration> {
+        if self.peers.is_empty() {
+            return None;
+        };
+        let averages: Vec<_> = self
+            .peers
+            .values()
+            .filter_map(|peer| peer.metrics.as_ref().map(|metrics| metrics.avg_commit_time))
+            .collect();
+        averages
+            .iter()
+            .sum::<Duration>()
+            .checked_div(averages.len() as u32)
+    }
+
+    fn update_peer(
+        &mut self,
+        peer: &ToriiUrl,
+        update: peer_monitor::Update,
+    ) -> Result<UpdatedSegment, PeerNotFound> {
+        let state = self.peers.get_mut(peer).ok_or(PeerNotFound)?;
+
+        let ret = match update {
+            peer_monitor::Update::Connected(config) => {
+                debug_assert!(!state.connected);
+                state.connected = true;
+                state.config = Some(config);
+                UpdatedSegment::Info(state.info())
+            }
+            peer_monitor::Update::Disconnected => {
+                debug_assert!(state.connected);
+                state.connected = false;
+                state.connected_peers = None;
+                state.metrics = None;
+                UpdatedSegment::Info(state.info())
+            }
+            peer_monitor::Update::Metrics(metrics) => {
+                debug_assert!(state.connected);
+                state.metrics = Some(metrics);
+                UpdatedSegment::Status(state.status().expect("must exists after setting metrics"))
+            }
+            peer_monitor::Update::Peers(peers) => {
+                debug_assert!(state.connected);
+                state.connected_peers = Some(peers);
+                UpdatedSegment::Info(state.info())
+            }
+            peer_monitor::Update::Geo(geo) => {
+                state.geo = Some(geo);
+                UpdatedSegment::Info(state.info())
+            }
+        };
+        Ok(ret)
+    }
+
+    fn update_blockchain(&mut self, state: blockchain::State) {
+        self.blockchain = Some(state);
+    }
+
+    fn network_status(&self) -> Option<NetworkStatus> {
+        self.blockchain.as_ref().map(|state| NetworkStatus {
+            peers: self.total_peers() as u32,
+            domains: state.domains,
+            accounts: state.accounts,
+            assets: state.assets,
+            transactions_accepted: state.txs_accepted,
+            transactions_rejected: state.txs_rejected,
+            block: state.block,
+            block_created_at: state.block_created_at.into(),
+            avg_block_time: state.avg_block_time.into(),
+            avg_commit_time: self.avg_commit_time().map(From::from),
+            finalized_block: self.finalized_block(),
+        })
+    }
+
+    fn peers_status(&self) -> impl Iterator<Item = PeerStatus> + use<'_> {
+        self.peers.values().filter_map(PeerState::status)
+    }
+
+    fn single_peer_status(&self, peer: &ToriiUrl) -> Option<PeerStatus> {
+        self.peers.get(peer).and_then(PeerState::status)
+    }
+
+    fn peers_info(&self) -> impl Iterator<Item = PeerInfo> + use<'_> {
+        self.peers.values().map(PeerState::info)
+    }
+
+    fn total_peers(&self) -> usize {
+        let all_pub_keys: BTreeSet<_> = self
+            .peers
+            .values()
+            .flat_map(|peer| {
+                peer.config
+                    .as_ref()
+                    .map(|cfg| &cfg.public_key)
+                    .into_iter()
+                    .chain(peer.connected_peers.iter().flat_map(|x| x.iter()))
+            })
+            .collect();
+
+        all_pub_keys.len()
+    }
+}
+
+#[derive(Debug)]
+enum UpdatedSegment {
+    Info(PeerInfo),
+    Status(PeerStatus),
+}
+
+impl From<UpdatedSegment> for TelemetryStreamMessage {
+    fn from(value: UpdatedSegment) -> Self {
+        match value {
+            UpdatedSegment::Info(data) => Self::PeerInfo(data),
+            UpdatedSegment::Status(data) => Self::PeerStatus(data),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PeerNotFound;
+
+struct PeerState {
+    url: ToriiUrl,
+    connected: bool,
+    config: Option<ConfigGetDTO>,
+    geo: Option<GeoLocation>,
+    connected_peers: Option<BTreeSet<PublicKey>>,
+    metrics: Option<peer_monitor::Metrics>,
+}
+
+impl PeerState {
+    fn new(url: ToriiUrl) -> Self {
+        Self {
+            url,
+            connected: false,
+            config: None,
+            geo: None,
+            connected_peers: None,
+            metrics: None,
+        }
+    }
+
+    fn info(&self) -> PeerInfo {
+        PeerInfo {
+            url: self.url.clone(),
+            connected: self.connected,
+            config: self.config.as_ref().map(|x| x.clone().into()),
+            location: self.geo.clone(),
+            connected_peers: self.connected_peers.as_ref().map(|x| {
+                x.iter()
+                    .map(|y| crate::schema::PublicKey(y.clone()))
+                    .collect()
+            }),
+        }
+    }
+
+    fn status(&self) -> Option<PeerStatus> {
+        self.metrics.as_ref().map(|metrics| PeerStatus {
+            url: self.url.clone(),
+            block: metrics.block,
+            commit_time: crate::schema::TimeDuration::from(metrics.block_commit_time),
+            avg_commit_time: crate::schema::TimeDuration::from(metrics.avg_commit_time),
+            queue_size: metrics.queue_size,
+            uptime: crate::schema::TimeDuration::from(metrics.uptime),
+        })
+    }
+}
+
+#[derive(Default)]
+struct AverageCommitTime<const N: usize> {
+    buff: CircularBuffer<N, Duration>,
+    last_height: Option<u64>,
+}
+
+impl<const N: usize> AverageCommitTime<N> {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn observe(&mut self, height: u64, block_time: Duration) {
+        if self.last_height.map(|x| x == height).unwrap_or(false) {
+            return;
+        }
+        self.last_height = Some(height);
+        self.buff.push_back(block_time);
+    }
+
+    fn calculate(&self) -> Option<Duration> {
+        let sum = self
+            .buff
+            .iter()
+            .fold(None, |acc, x| Some(acc.unwrap_or(Duration::ZERO) + *x));
+        sum.map(|sum| {
+            sum.checked_div(self.buff.len() as u32)
+                .expect("non-zero if sum exists")
+        })
+    }
+}
+
+#[cfg(test)]
+mod avg_commit_tests {
+    use super::*;
+
+    #[test]
+    fn avg_commit_time_is_empty() {
+        let avg = AverageCommitTime::<5>::new();
+        assert!(avg.calculate().is_none())
+    }
+
+    #[test]
+    fn avg_commit_time_calculates_latest_n_window() {
+        // duration, windowed mean (4)
+        let series = [
+            (100u64, 100u128),
+            (150, 125),
+            (200, 150),
+            (10, 115),
+            (45, 101),
+            (120, 93),
+            (350, 131),
+        ];
+
+        let mut avg = AverageCommitTime::<4>::new();
+
+        for (i, (ms, mean_ms)) in series.iter().enumerate() {
+            avg.observe(i as u64 + 1, Duration::from_millis(*ms));
+            let value = avg.calculate().unwrap();
+            assert_eq!(value.as_millis(), *mean_ms);
+        }
+    }
+
+    #[test]
+    fn avg_commit_time_deduplicates_by_height() {
+        let mut avg = AverageCommitTime::<10>::new();
+
+        avg.observe(1, Duration::from_millis(100));
+        avg.observe(2, Duration::from_millis(200));
+        avg.observe(2, Duration::from_millis(300)); // ignore
+        avg.observe(3, Duration::from_millis(400));
+
+        assert_eq!(avg.calculate().unwrap().as_millis(), (100 + 200 + 400) / 3)
+    }
+}
+
+#[cfg(test)]
+mod state_tests {
+    use super::*;
+    use crate::telemetry::peer_monitor::{Metrics, Update};
+    use insta::assert_json_snapshot;
+    use iroha::client::ConfigGetDTO;
+    use serde_json::json;
+
+    fn factory_key(seed: impl AsRef<[u8]>) -> PublicKey {
+        iroha_crypto::KeyPair::from_seed(seed.as_ref().into(), <_>::default())
+            .public_key()
+            .clone()
+    }
+
+    fn factory_url(id: impl std::fmt::Display) -> ToriiUrl {
+        ToriiUrl(format!("http://iroha.tech/{}", id).parse().unwrap())
+    }
+
+    fn factory_block_state() -> blockchain::State {
+        blockchain::State {
+            block: 0,
+            block_created_at: <_>::default(),
+            domains: 0,
+            accounts: 0,
+            assets: 0,
+            txs_accepted: 0,
+            txs_rejected: 0,
+            // parameter_max_block_time: Duration::ZERO,
+            // parameter_max_commit_time: Duration::ZERO,
+            // parameter_max_txs_per_block: 0,
+            avg_block_time: Duration::ZERO,
+        }
+    }
+
+    fn factory_config(seed: impl AsRef<[u8]>) -> ConfigGetDTO {
+        serde_json::from_value(json!({
+            "public_key": factory_key(seed),
+            "logger": {
+                "level": "INFO",
+                "filter": null
+            },
+            "network": {
+                "block_gossip_size": 4,
+                "block_gossip_period_ms": 10000,
+                "transaction_gossip_size": 500,
+                "transaction_gossip_period_ms": 1000
+            },
+            "queue": {
+                "capacity": 65536
+            }
+        }))
+        .unwrap()
+    }
+
+    fn factory_metrics() -> Metrics {
+        Metrics {
+            peers: 0,
+            block: 0,
+            block_commit_time: Duration::ZERO,
+            avg_commit_time: Duration::ZERO,
+            queue_size: 0,
+            uptime: Duration::ZERO,
+        }
+    }
+
+    #[test]
+    fn empty() {
+        let peer_0 = factory_url("0");
+        let peer_1 = factory_url("1");
+        let peer_2 = factory_url("2");
+        let peer_3 = factory_url("3");
+        let state = State::new([peer_0, peer_1, peer_2, peer_3].into_iter().collect());
+
+        assert!(state.network_status().is_none());
+        let info: Vec<_> = state.peers_info().collect();
+        assert_json_snapshot!(info);
+        let peers: Vec<_> = state.peers_status().collect();
+        assert!(peers.is_empty())
+    }
+
+    #[test]
+    fn counts_all_peers_via_public_keys() {
+        let url1 = factory_url("1");
+        let key1 = factory_key(b"1");
+        let url2 = factory_url("2");
+        let key2 = factory_key(b"2");
+        let key3 = factory_key(b"3");
+        let key4 = factory_key(b"4");
+        let mut state = State::new([&url1, &url2].into_iter().cloned().collect());
+
+        // 1 -> 2, 3
+        // 2 -> 4
+        // total - 4 different peers
+        let _ = state.update_peer(
+            &url1,
+            Update::Connected(ConfigGetDTO {
+                public_key: key1.clone().into(),
+                ..factory_config(b"key 1")
+            }),
+        );
+        let _ = state.update_peer(
+            &url1,
+            Update::Peers([&key2, &key3].into_iter().cloned().collect()),
+        );
+        let _ = state.update_peer(
+            &url2,
+            Update::Connected(ConfigGetDTO {
+                public_key: key2.clone().into(),
+                ..factory_config(b"key 2")
+            }),
+        );
+        let _ = state.update_peer(&url2, Update::Peers([&key4].into_iter().cloned().collect()));
+        state.update_blockchain(factory_block_state());
+
+        let network = state.network_status().unwrap();
+        assert_eq!(network.peers, 4);
+    }
+
+    struct FinalizedBlockHelper {
+        state: State,
+    }
+
+    impl FinalizedBlockHelper {
+        fn new<const N: usize>(urls: [&ToriiUrl; N]) -> Self {
+            let mut state = State::new(urls.clone().into_iter().cloned().collect());
+            for (i, url) in urls.into_iter().enumerate() {
+                state
+                    .update_peer(url, Update::Connected(factory_config([i as u8])))
+                    .unwrap();
+            }
+            Self { state }
+        }
+
+        fn update_block(&mut self, url: &ToriiUrl, block: u32) {
+            self.state
+                .update_peer(
+                    &url,
+                    Update::Metrics(Metrics {
+                        block,
+                        ..factory_metrics()
+                    }),
+                )
+                .unwrap();
+        }
+
+        fn assert(&self, expected: Option<u32>) {
+            assert_eq!(self.state.finalized_block(), expected);
+        }
+    }
+
+    #[test]
+    fn finalized_block_by_supermajority() {
+        let url1 = factory_url("1");
+        let url2 = factory_url("2");
+        let url3 = factory_url("3");
+        let url4 = factory_url("4");
+        let mut helper = FinalizedBlockHelper::new([&url1, &url2, &url3, &url4]);
+
+        helper.assert(None); // no peers data yet
+        helper.update_block(&url1, 1);
+        helper.assert(None); // minority
+        helper.update_block(&url2, 1);
+        helper.assert(None); // still minority
+        helper.update_block(&url3, 1);
+        helper.assert(Some(1));
+        helper.update_block(&url4, 1);
+        helper.assert(Some(1));
+        helper.update_block(&url1, 4);
+        helper.assert(Some(1));
+        helper.update_block(&url2, 4);
+        helper.assert(Some(1));
+        helper.update_block(&url3, 2);
+        helper.assert(Some(2));
+        helper.update_block(&url4, 3);
+        helper.assert(Some(3));
+        helper.update_block(&url3, 4);
+        helper.assert(Some(4));
+        helper.update_block(&url1, 5);
+        helper.assert(Some(4));
+    }
+
+    #[test]
+    fn finalized_block_2_peers() {
+        let url1 = factory_url("1");
+        let url2 = factory_url("2");
+        let mut helper = FinalizedBlockHelper::new([&url1, &url2]);
+
+        helper.update_block(&url1, 1);
+        helper.assert(None);
+        helper.update_block(&url1, 2);
+        helper.assert(None);
+        helper.update_block(&url2, 1);
+        helper.assert(Some(1));
+    }
+
+    #[test]
+    fn finalized_block_1_peer() {
+        let url = factory_url("only");
+        let mut helper = FinalizedBlockHelper::new([&url]);
+
+        helper.update_block(&url, 1);
+        helper.assert(Some(1));
+        helper.update_block(&url, 2);
+        helper.assert(Some(2));
+    }
+
+    #[test]
+    fn full_peer_update_cycle() {
+        let url = factory_url("test");
+        let mut state = State::new([&url].into_iter().cloned().collect());
+
+        let _ = state.update_peer(&url, Update::Connected(factory_config(b"test")));
+        let _ = state.update_peer(
+            &url,
+            Update::Geo(GeoLocation {
+                lat: 55,
+                long: 32,
+                country: "Wonderland".to_owned(),
+                city: "Makondo".to_owned(),
+            }),
+        );
+        let _ = state.update_peer(
+            &url,
+            Update::Metrics(Metrics {
+                avg_commit_time: Duration::from_millis(122),
+                ..factory_metrics()
+            }),
+        );
+        let _ = state.update_peer(
+            &url,
+            Update::Peers(
+                [factory_key(b"one"), factory_key(b"two")]
+                    .into_iter()
+                    .collect(),
+            ),
+        );
+
+        let info = state.peers_info().find(|x| &x.url == &url).unwrap();
+        let status = state.single_peer_status(&url).expect("must be");
+        assert_json_snapshot!(info);
+        assert_json_snapshot!(status);
+
+        let _ = state.update_peer(&url, Update::Disconnected);
+
+        let info = state.peers_info().find(|x| &x.url == &url).unwrap();
+        assert!(info.config.is_some());
+        assert!(info.location.is_some());
+        assert!(info.connected_peers.is_none());
+
+        let status = state.single_peer_status(&url);
+        assert!(status.is_none());
+    }
+
+    #[test]
+    fn no_peers_no_avg_block() {
+        let state = State::new(<_>::default());
+        assert_eq!(state.avg_commit_time(), None);
+    }
+}

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -653,7 +653,7 @@ mod state_tests {
         let _ = state.update_peer(
             &url1,
             Update::Connected(ConfigGetDTO {
-                public_key: key1.clone().into(),
+                public_key: key1.clone(),
                 ..factory_config(b"key 1")
             }),
         );
@@ -664,7 +664,7 @@ mod state_tests {
         let _ = state.update_peer(
             &url2,
             Update::Connected(ConfigGetDTO {
-                public_key: key2.clone().into(),
+                public_key: key2.clone(),
                 ..factory_config(b"key 2")
             }),
         );
@@ -681,7 +681,7 @@ mod state_tests {
 
     impl FinalizedBlockHelper {
         fn new<const N: usize>(urls: [&ToriiUrl; N]) -> Self {
-            let mut state = State::new(urls.clone().into_iter().cloned().collect());
+            let mut state = State::new(urls.into_iter().cloned().collect());
             for (i, url) in urls.into_iter().enumerate() {
                 state
                     .update_peer(url, Update::Connected(factory_config([i as u8])))
@@ -693,7 +693,7 @@ mod state_tests {
         fn update_block(&mut self, url: &ToriiUrl, block: u32) {
             self.state
                 .update_peer(
-                    &url,
+                    url,
                     Update::Metrics(Metrics {
                         block,
                         ..factory_metrics()
@@ -794,14 +794,14 @@ mod state_tests {
             ),
         );
 
-        let info = state.peers_info().find(|x| &x.url == &url).unwrap();
+        let info = state.peers_info().find(|x| x.url == url).unwrap();
         let status = state.single_peer_status(&url).expect("must be");
         assert_json_snapshot!(info);
         assert_json_snapshot!(status);
 
         let _ = state.update_peer(&url, Update::Disconnected);
 
-        let info = state.peers_info().find(|x| &x.url == &url).unwrap();
+        let info = state.peers_info().find(|x| x.url == url).unwrap();
         assert!(info.config.is_some());
         assert!(info.location.is_some());
         assert!(info.connected_peers.is_none());
@@ -829,7 +829,7 @@ mod state_tests {
         };
         state.update_peer(&url, Update::Geo(geo.clone())).unwrap();
 
-        let info = state.peers_info().find(|x| &x.url == &url).unwrap();
+        let info = state.peers_info().find(|x| x.url == url).unwrap();
         assert_eq!(info.location, Some(geo));
     }
 
@@ -845,14 +845,14 @@ mod state_tests {
             .update_peer(&url, Update::TelemetryUnsupported)
             .unwrap();
 
-        let info = state.peers_info().find(|x| &x.url == &url).unwrap();
+        let info = state.peers_info().find(|x| x.url == url).unwrap();
         assert!(info.telemetry_unsupported);
 
         state
             .update_peer(&url, Update::Metrics(factory_metrics()))
             .unwrap();
 
-        let info = state.peers_info().find(|x| &x.url == &url).unwrap();
+        let info = state.peers_info().find(|x| x.url == url).unwrap();
         assert!(!info.telemetry_unsupported);
     }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -350,7 +350,7 @@ impl State {
             transactions_rejected: state.txs_rejected,
             block: state.block,
             block_created_at: state.block_created_at.into(),
-            avg_block_time: state.avg_block_time.into(),
+            avg_block_time: state.avg_block_time.0.into(),
             avg_commit_time: self.avg_commit_time().map(From::from),
             finalized_block: self.finalized_block(),
         })
@@ -459,6 +459,8 @@ struct AverageCommitTime<const N: usize> {
     last_height: Option<u64>,
 }
 
+const AVG_COMMIT_BLOCK_TIME_WINDOW: usize = 16;
+
 impl<const N: usize> AverageCommitTime<N> {
     fn new() -> Self {
         Self::default()
@@ -532,6 +534,7 @@ mod avg_commit_tests {
 #[cfg(test)]
 mod state_tests {
     use super::*;
+    use crate::telemetry::blockchain::DurationMillis;
     use crate::telemetry::peer_monitor::{Metrics, Update};
     use insta::assert_json_snapshot;
     use iroha::client::ConfigGetDTO;
@@ -559,7 +562,7 @@ mod state_tests {
             // parameter_max_block_time: Duration::ZERO,
             // parameter_max_commit_time: Duration::ZERO,
             // parameter_max_txs_per_block: 0,
-            avg_block_time: Duration::ZERO,
+            avg_block_time: DurationMillis(Duration::ZERO),
         }
     }
 

--- a/src/telemetry/blockchain.rs
+++ b/src/telemetry/blockchain.rs
@@ -17,7 +17,7 @@ pub struct State {
 }
 
 impl State {
-    pub async fn scan(repo: &Repo) -> Result<Self, crate::repo::Error> {
+    pub async fn scan(_repo: &Repo) -> Result<Self, crate::repo::Error> {
         todo!()
     }
 }

--- a/src/telemetry/blockchain.rs
+++ b/src/telemetry/blockchain.rs
@@ -1,7 +1,25 @@
 use crate::repo::Repo;
+use crate::telemetry::AVG_COMMIT_BLOCK_TIME_WINDOW;
+use sqlx::FromRow;
+use std::convert::Infallible;
 use std::time::Duration;
 
-#[derive(Clone)]
+const QUERY: &str = "\
+select (select count() from blocks)                                            as block,
+       (select created_at from blocks order by blocks.created_at desc limit 1) as block_created_at,
+       (select count() from domains)                                           as domains,
+       (select count() from accounts)                                          as accounts,
+       (select count() from assets) + (select count() from nfts)               as assets,
+       (select count() from transactions where error is null)                  as txs_accepted,
+       (select count() from transactions where error is not null)              as txs_rejected,
+       (select cast(((max(unixepoch(created_at, 'subsec')) -
+                      min(unixepoch(created_at, 'subsec'))) * 1000) / count(distinct created_at) as integer)
+        from (select created_at
+              from blocks
+              order by created_at desc
+              limit ?))                                                       as avg_block_time_ms";
+
+#[derive(Clone, Debug, FromRow)]
 pub struct State {
     pub block: u32,
     pub block_created_at: chrono::DateTime<chrono::Utc>,
@@ -13,11 +31,43 @@ pub struct State {
     // pub parameter_max_block_time: Duration,
     // pub parameter_max_commit_time: Duration,
     // pub parameter_max_txs_per_block: u32,
-    pub avg_block_time: Duration,
+    #[sqlx(rename = "avg_block_time_ms", try_from = "u64")]
+    pub avg_block_time: DurationMillis,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct DurationMillis(pub Duration);
+
+impl TryFrom<u64> for DurationMillis {
+    type Error = Infallible;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Ok(Self(Duration::from_millis(value)))
+    }
 }
 
 impl State {
-    pub async fn scan(_repo: &Repo) -> Result<Self, crate::repo::Error> {
-        todo!()
+    pub async fn scan(repo: &Repo) -> Result<Self, crate::repo::Error> {
+        let mut conn = repo.acquire_conn().await;
+        let state: State = sqlx::query_as(QUERY)
+            .bind(AVG_COMMIT_BLOCK_TIME_WINDOW as u32)
+            .fetch_one(&mut *conn)
+            .await?;
+        Ok(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repo::tests::test_repo;
+    use insta::assert_debug_snapshot;
+
+    #[tokio::test]
+    async fn scan_test_repo() {
+        let repo = test_repo().await;
+
+        let state = State::scan(&repo).await.unwrap();
+        assert_debug_snapshot!(state);
     }
 }

--- a/src/telemetry/blockchain.rs
+++ b/src/telemetry/blockchain.rs
@@ -1,0 +1,23 @@
+use crate::repo::Repo;
+use std::time::Duration;
+
+#[derive(Clone)]
+pub struct State {
+    pub block: u32,
+    pub block_created_at: chrono::DateTime<chrono::Utc>,
+    pub domains: u32,
+    pub accounts: u32,
+    pub assets: u32,
+    pub txs_accepted: u32,
+    pub txs_rejected: u32,
+    // pub parameter_max_block_time: Duration,
+    // pub parameter_max_commit_time: Duration,
+    // pub parameter_max_txs_per_block: u32,
+    pub avg_block_time: Duration,
+}
+
+impl State {
+    pub async fn scan(repo: &Repo) -> Result<Self, crate::repo::Error> {
+        todo!()
+    }
+}

--- a/src/telemetry/peer_monitor.rs
+++ b/src/telemetry/peer_monitor.rs
@@ -25,7 +25,7 @@ const GET_PEERS_INTERVAL: Duration = Duration::from_secs(60);
 const TELEMETRY_UNSUPPORTED_CHECK_INTERVAL: Duration = Duration::from_secs(300);
 const GET_GEO_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 const GET_CONFIG_INIT_INTERVAL: Duration = Duration::from_secs(15);
-const GET_CONFIG_MAX_INTERVAL: Duration = Duration::from_secs(300);
+const GET_CONFIG_MAX_INTERVAL: Duration = Duration::from_secs(120);
 const GET_CONFIG_INTERVAL_MULTIPLIER: f64 = 1.67;
 
 #[instrument(fields(%torii_url))]
@@ -284,7 +284,9 @@ async fn get_metrics_periodic_timeout(torii_url: &ToriiUrl, tx: mpsc::Sender<Upd
                 tracing::warn!(?err, "Failed to get status");
                 let elapsed = Instant::now() - count_failure_from;
                 if elapsed >= GET_STATUS_DISCONNECT_TIMEOUT {
-                    tracing::warn!(%url, "")
+                    tracing::warn!(%url, "Peer does not respond for too long, terminate status checks");
+                    // disconnected message is sent externally
+                    break;
                 }
             }
             Err(GetError::NotImplemented) => {

--- a/src/telemetry/peer_monitor.rs
+++ b/src/telemetry/peer_monitor.rs
@@ -1,0 +1,40 @@
+use crate::schema::GeoLocation;
+use crate::schema::ToriiUrl;
+use iroha::client::ConfigGetDTO;
+use iroha::crypto::PublicKey;
+use std::collections::BTreeSet;
+use std::future::Future;
+use std::time::Duration;
+use tokio::sync::broadcast;
+
+pub fn run(
+    url: ToriiUrl,
+) -> (
+    broadcast::Receiver<Update>,
+    impl Future<Output = ()> + Sized,
+) {
+    let (tx, rx) = broadcast::channel(128);
+
+    let fut = async move { todo!() };
+
+    (rx, fut)
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Metrics {
+    pub peers: u32,
+    pub block: u32,
+    pub block_commit_time: Duration,
+    pub avg_commit_time: Duration,
+    pub queue_size: u32,
+    pub uptime: Duration,
+}
+
+#[derive(Clone, Debug)]
+pub enum Update {
+    Connected(ConfigGetDTO),
+    Disconnected,
+    Metrics(Metrics),
+    Geo(GeoLocation),
+    Peers(BTreeSet<PublicKey>),
+}

--- a/src/telemetry/peer_monitor.rs
+++ b/src/telemetry/peer_monitor.rs
@@ -268,7 +268,7 @@ async fn get_metrics_periodic_timeout(torii_url: &ToriiUrl, tx: mpsc::Sender<Upd
             Ok(status) => {
                 tracing::trace!(?status, "Collected status");
                 count_failure_from = Instant::now();
-                let block_commit_time = Duration::from_millis(status.last_block_commit_time_ms);
+                let block_commit_time = Duration::from_millis(status.commit_time_ms);
                 avg_commit_time.observe(status.blocks, block_commit_time);
                 let metrics = Metrics {
                     // peers: status.peers as u32,

--- a/src/telemetry/peer_monitor.rs
+++ b/src/telemetry/peer_monitor.rs
@@ -1,28 +1,306 @@
 use crate::schema::GeoLocation;
 use crate::schema::ToriiUrl;
-use iroha::client::ConfigGetDTO;
+use crate::telemetry::AverageCommitTime;
+use eyre::eyre;
+use http::StatusCode;
+use iroha::client::{ConfigGetDTO, Status};
 use iroha::crypto::PublicKey;
+use iroha::data_model::peer::Peer;
+use iroha::data_model::Identifiable;
+use reqwest::Client;
+use serde::Deserialize;
 use std::collections::BTreeSet;
 use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::broadcast;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinSet;
+use tokio::time::{Instant, MissedTickBehavior};
+use tracing::{info_span, instrument, Instrument};
+use url::Url;
 
-pub fn run(
-    url: ToriiUrl,
-) -> (
-    broadcast::Receiver<Update>,
-    impl Future<Output = ()> + Sized,
-) {
-    let (tx, rx) = broadcast::channel(128);
+const GET_STATUS_INTERVAL: Duration = Duration::from_secs(5);
+const GET_STATUS_DISCONNECT_TIMEOUT: Duration = Duration::from_secs(60);
+const GET_PEERS_INTERVAL: Duration = Duration::from_secs(60);
+const TELEMETRY_UNSUPPORTED_CHECK_INTERVAL: Duration = Duration::from_secs(300);
+const GET_GEO_RETRY_INTERVAL: Duration = Duration::from_secs(60);
+const GET_CONFIG_INIT_INTERVAL: Duration = Duration::from_secs(15);
+const GET_CONFIG_MAX_INTERVAL: Duration = Duration::from_secs(300);
+const GET_CONFIG_INTERVAL_MULTIPLIER: f64 = 1.67;
+const AVG_COMMIT_TIME_WINDOW: usize = 16;
 
-    let fut = async move { todo!() };
+#[instrument(fields(%torii_url))]
+pub fn run(torii_url: ToriiUrl) -> (mpsc::Receiver<Update>, impl Future<Output = ()> + Sized) {
+    let (tx, rx) = mpsc::channel(128);
+    let url = Arc::new(torii_url);
+
+    let url2 = url.clone();
+    let fut = async move {
+        let mut set = JoinSet::new();
+
+        set.spawn({
+            let tx = tx.clone();
+            let url3 = url2.clone();
+            async move {
+                let geo = match collect_geo(&url3).await {
+                    Ok(x) => x,
+                    Err(err) => {
+                        tracing::error!(%err, "Failed to collect geo, quitting");
+                        return;
+                    }
+                };
+                tracing::debug!(?geo, "Collected peer geo data");
+                let _: Result<_, _> = tx.send(Update::Geo(geo)).await;
+            }
+            .instrument(info_span!("geo_future", torii_url = %url2))
+        });
+
+        set.spawn(
+            {
+                let url3 = url2.clone();
+                async move {
+                    loop {
+                        let cfg = get_config_with_retry(&url3).await;
+                        tracing::debug!(?cfg, "Peer connected");
+                        let _ = tx.send(Update::Connected(cfg)).await;
+
+                        let (status_fin_tx, status_fin_rx) = oneshot::channel();
+                        let mut set = JoinSet::new();
+                        set.spawn({
+                            let tx = tx.clone();
+                            let url = url3.clone();
+                            async move {
+                                get_peers_periodic(&url, tx).await;
+                                unreachable!("should never stop")
+                            }
+                        });
+                        set.spawn({
+                            let tx = tx.clone();
+                            let url = url3.clone();
+                            async move {
+                                get_metrics_periodic_timeout(&url, tx).await;
+                                let _: Result<_, _> = status_fin_tx.send(());
+                            }
+                        });
+                        status_fin_rx.await.expect("sender should not be dropped");
+                        tracing::warn!(
+                            "Peer stopped responding with status, marking as disconnected"
+                        );
+                        let _ = tx.send(Update::Disconnected).await;
+                    }
+                }
+            }
+            .instrument(info_span!("peer_future", torii_url = %url2)),
+        );
+
+        while set.join_next().await.is_some() {}
+        unreachable!("loop should never end");
+    };
 
     (rx, fut)
 }
 
+async fn collect_geo(torii_url: &ToriiUrl) -> eyre::Result<GeoLocation> {
+    #[derive(Deserialize, Debug)]
+    #[serde(tag = "status", rename_all = "lowercase")]
+    enum IpApiComResponse {
+        Success(GeoLocation),
+        Fail { message: String },
+    }
+
+    #[derive(thiserror::Error, Debug)]
+    enum RequestError {
+        #[error("Request to ip-api.com failed: {0:?}")]
+        Http(#[from] reqwest::Error),
+        #[error("Request to ip-api.com failed with message: {message}")]
+        FailResponse { message: String },
+    }
+
+    let client = Client::new();
+    let url = construct_ip_api_com_query(torii_url)?;
+    let do_request = || {
+        let client = client.clone();
+        let url = url.clone();
+        async move {
+            let response: IpApiComResponse = client.get(url).send().await?.json().await?;
+            match response {
+                IpApiComResponse::Success(data) => Ok(data),
+                IpApiComResponse::Fail { message } => Err(RequestError::FailResponse { message }),
+            }
+        }
+    };
+
+    let data = backoff::future::retry(
+        backoff::ExponentialBackoffBuilder::new()
+            .with_initial_interval(GET_GEO_RETRY_INTERVAL)
+            .with_multiplier(1.0)
+            .with_max_elapsed_time(None)
+            .build(),
+        || async {
+            match do_request().await {
+                Ok(data) => Ok(data),
+                Err(RequestError::Http(err)) => {
+                    tracing::warn!(%err, "Failed to get geo location (http error, will retry)");
+                    Err(backoff::Error::transient(eyre!("{err}")))
+                }
+                Err(RequestError::FailResponse { message }) => {
+                    tracing::error!(response = %message, "Failed to get geo location (service error, will not retry)");
+                    Err(backoff::Error::permanent(eyre!("Got fail response")))
+                }
+            }
+        },
+    )
+    .await?;
+
+    Ok(data)
+}
+
+fn construct_ip_api_com_query(torii_url: &ToriiUrl) -> Result<Url, eyre::Error> {
+    let Some(host) = torii_url.0.host_str() else {
+        return Err(eyre!("Torii URL does not have host"));
+    };
+    let mut url = Url::parse("http://ip-api.com/json").expect("valid");
+    url.path_segments_mut().expect("url has a base").push(host);
+    url.query_pairs_mut()
+        .append_pair("fields", "status,message,lat,lon,country,city");
+    Ok(url)
+}
+
+async fn get_config_with_retry(torii_url: &ToriiUrl) -> ConfigGetDTO {
+    let client = Client::new();
+    let url = torii_url.0.join("/configuration").expect("valid url");
+
+    let do_request = || {
+        let client = client.clone();
+        let url = url.clone();
+        async move {
+            let config: ConfigGetDTO = client.get(url).send().await?.json().await?;
+            Ok::<_, reqwest::Error>(config)
+        }
+    };
+
+    backoff::future::retry(
+        backoff::ExponentialBackoffBuilder::new()
+            .with_initial_interval(GET_CONFIG_INIT_INTERVAL)
+            .with_max_interval(GET_CONFIG_MAX_INTERVAL)
+            .with_multiplier(GET_CONFIG_INTERVAL_MULTIPLIER)
+            .with_max_elapsed_time(None)
+            .build(),
+        || async {
+            tracing::debug!("Trying to get configuration");
+            match do_request().await {
+                Ok(x) => Ok(x),
+                Err(err) => {
+                    tracing::warn!(?err, "Failed to get configuration");
+                    Err(err)?
+                }
+            }
+        },
+    )
+    .await
+    .expect("there is no retry limit")
+}
+
+#[instrument(skip(tx), fields(%torii_url))]
+async fn get_peers_periodic(torii_url: &ToriiUrl, tx: mpsc::Sender<Update>) -> NoReturn {
+    let client = Client::new();
+    let url = torii_url.0.join("/peers").expect("valid url");
+    let get = || async {
+        let peers: Vec<Peer> = client.get(url.clone()).send().await?.json().await?;
+        Ok::<_, reqwest::Error>(peers)
+    };
+
+    let mut interval = tokio::time::interval(GET_PEERS_INTERVAL);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    loop {
+        tracing::trace!("Collecting peers");
+        match get().await {
+            Ok(peers) => {
+                tracing::trace!(?peers, "Collected peers from peer");
+                let _ = tx
+                    .send(Update::Peers(
+                        peers
+                            .into_iter()
+                            .map(|x| x.id().public_key().clone())
+                            .collect(),
+                    ))
+                    .await;
+            }
+            Err(err) => {
+                tracing::warn!(?err, "Failed to get peers from peer");
+            }
+        }
+        interval.tick().await;
+    }
+}
+
+enum NoReturn {}
+
+#[instrument(skip(tx), fields(%torii_url))]
+async fn get_metrics_periodic_timeout(torii_url: &ToriiUrl, tx: mpsc::Sender<Update>) {
+    #[derive(thiserror::Error, Debug)]
+    enum GetError {
+        #[error("http error: {0}")]
+        Http(#[from] reqwest::Error),
+        #[error("telemetry is not available")]
+        NotImplemented,
+    }
+
+    let mut avg_commit_time = AverageCommitTime::<AVG_COMMIT_TIME_WINDOW>::new();
+    let client = Client::new();
+    let url = torii_url.0.join("/status").expect("valid url");
+    let get = || async {
+        let resp = client.get(url.clone()).send().await?;
+        if resp.status() == StatusCode::NOT_IMPLEMENTED {
+            return Err(GetError::NotImplemented);
+        }
+        let status: Status = resp.json().await?;
+        Ok(status)
+    };
+
+    let mut interval = tokio::time::interval(GET_STATUS_INTERVAL);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    let mut count_failure_from: Instant = Instant::now();
+
+    loop {
+        tracing::trace!("Collecting status");
+        match get().await {
+            Ok(status) => {
+                tracing::trace!(?status, "Collected status");
+                count_failure_from = Instant::now();
+                let block_commit_time = Duration::from_millis(status.last_block_commit_time_ms);
+                avg_commit_time.observe(status.blocks, block_commit_time);
+                let metrics = Metrics {
+                    // peers: status.peers as u32,
+                    block: status.blocks as u32,
+                    block_commit_time,
+                    avg_commit_time: avg_commit_time.calculate().expect("BUG: just updated"),
+                    queue_size: status.queue_size as u32,
+                    uptime: status.uptime.0,
+                };
+                let _ = tx.send(Update::Metrics(metrics)).await;
+            }
+            Err(GetError::Http(err)) => {
+                tracing::warn!(?err, "Failed to get status");
+                let elapsed = Instant::now() - count_failure_from;
+                if elapsed >= GET_STATUS_DISCONNECT_TIMEOUT {
+                    tracing::warn!(%url, "")
+                }
+            }
+            Err(GetError::NotImplemented) => {
+                tracing::info!("Peer does not implement telemetry");
+                let _ = tx.send(Update::TelemetryUnsupported).await;
+                tokio::time::sleep(TELEMETRY_UNSUPPORTED_CHECK_INTERVAL).await;
+            }
+        }
+        interval.tick().await;
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct Metrics {
-    pub peers: u32,
+    // pub peers: u32,
     pub block: u32,
     pub block_commit_time: Duration,
     pub avg_commit_time: Duration,
@@ -34,7 +312,42 @@ pub struct Metrics {
 pub enum Update {
     Connected(ConfigGetDTO),
     Disconnected,
+    TelemetryUnsupported,
     Metrics(Metrics),
     Geo(GeoLocation),
     Peers(BTreeSet<PublicKey>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::spawn;
+
+    #[test]
+    fn construct_ip_api_com_urls() {
+        let result = construct_ip_api_com_query(&"http://iroha.tech/".parse().unwrap()).unwrap();
+        assert_eq!(
+            result.to_string(),
+            "http://ip-api.com/json/iroha.tech?fields=status%2Cmessage%2Clat%2Clon%2Ccountry%2Ccity"
+        );
+
+        let result =
+            construct_ip_api_com_query(&"https://fujiwara.sora.org/v5".parse().unwrap()).unwrap();
+        assert_eq!(
+            result.to_string(),
+            "http://ip-api.com/json/fujiwara.sora.org?fields=status%2Cmessage%2Clat%2Clon%2Ccountry%2Ccity"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn debug_monitor() {
+        crate::init_test_logger();
+        let (mut rx, fut) = run("http://localhost:8080".parse().unwrap());
+        spawn(fut);
+
+        while let Some(msg) = rx.recv().await {
+            tracing::info!(?msg, "Message from monitor");
+        }
+    }
 }

--- a/src/telemetry/peer_monitor.rs
+++ b/src/telemetry/peer_monitor.rs
@@ -1,6 +1,6 @@
 use crate::schema::GeoLocation;
 use crate::schema::ToriiUrl;
-use crate::telemetry::AverageCommitTime;
+use crate::telemetry::{AverageCommitTime, AVG_COMMIT_BLOCK_TIME_WINDOW};
 use eyre::eyre;
 use http::StatusCode;
 use iroha::client::{ConfigGetDTO, Status};
@@ -27,7 +27,6 @@ const GET_GEO_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 const GET_CONFIG_INIT_INTERVAL: Duration = Duration::from_secs(15);
 const GET_CONFIG_MAX_INTERVAL: Duration = Duration::from_secs(300);
 const GET_CONFIG_INTERVAL_MULTIPLIER: f64 = 1.67;
-const AVG_COMMIT_TIME_WINDOW: usize = 16;
 
 #[instrument(fields(%torii_url))]
 pub fn run(torii_url: ToriiUrl) -> (mpsc::Receiver<Update>, impl Future<Output = ()> + Sized) {
@@ -247,7 +246,7 @@ async fn get_metrics_periodic_timeout(torii_url: &ToriiUrl, tx: mpsc::Sender<Upd
         NotImplemented,
     }
 
-    let mut avg_commit_time = AverageCommitTime::<AVG_COMMIT_TIME_WINDOW>::new();
+    let mut avg_commit_time = AverageCommitTime::<AVG_COMMIT_BLOCK_TIME_WINDOW>::new();
     let client = Client::new();
     let url = torii_url.0.join("/status").expect("valid url");
     let get = || async {

--- a/src/telemetry/snapshots/iroha_explorer__telemetry__blockchain__tests__scan_test_repo.snap
+++ b/src/telemetry/snapshots/iroha_explorer__telemetry__blockchain__tests__scan_test_repo.snap
@@ -1,0 +1,16 @@
+---
+source: src/telemetry/blockchain.rs
+expression: state
+---
+State {
+    block: 17,
+    block_created_at: 2025-04-03T03:18:01.509Z,
+    domains: 4,
+    accounts: 6,
+    assets: 4,
+    txs_accepted: 14,
+    txs_rejected: 4,
+    avg_block_time: DurationMillis(
+        2.843s,
+    ),
+}


### PR DESCRIPTION
TODO:

- [x] Implement actual gathering in `peer_monitor`
- [x] Implement blockchain data collection
- [x] OpenAPI specs
- [x] Merge https://github.com/hyperledger-iroha/iroha/pull/5380 and reference updated Iroha in Cargo.toml.

### Overview

- Accepts list or Torii URLs in the configuration
- Continuously gather various information for each peer:
  - Its configuration
  - Its online peers
  - Its high-level metrics (requires `telemetry` feature in `irohad`)
  - Its geographical location by querying the host name of the peer URL to http://ip-api.com
- Provide information such as status connection and telemetry support by the peer
- Serve telemetry via oneshot requests __or__ via a live-stream as updates are available
- Improve and organise OpenAPI docs

Caveats:

- Does not support dynamic peers updates
- Does not support automatic peers discovery (see https://github.com/hyperledger-iroha/iroha/issues/5367)

### API Changes

- Removed **`GET /status`**
- Added **`GET /telemetry/network`** for network metrics
- Added **`GET /telemetry/peers`** for peers metrics (frequently updated)
- Added **`GET /telemetry/peers-info`** for peers info (less frequently updated)
- Added **`GET /telemetry/live`** for live updates of __all abovementioned data__ via Server-Sent Events

### Config Changes

Renamed ~~`--torii-url` (`IROHA_EXPLORER_TORII_URL`)~~ to `--torii-urls` (`IROHA_EXPLORER_TORII_URLS`) (url*s*) for comma-separated URLs of peers. 