### PR TITLE
docs: actualise README, extend `--version` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-str"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e991226a70654b49d34de5ed064885f0bef0348a8e70018b8ff1ac80aa984a2"
+dependencies = [
+ "const-str-proc-macro",
+]
+
+[[package]]
+name = "const-str-proc-macro"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d1c4c3cb85e5856b34e829af0035d7154f8c2889b15bbf43c8a6c6786dcab5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,8 +2503,8 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iroha"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "attohttpc",
  "base64",
@@ -2519,8 +2539,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_config"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "cfg-if",
  "derive_more 0.99.19",
@@ -2546,8 +2566,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_config_base"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "derive_more 0.99.19",
  "drop_bomb",
@@ -2563,8 +2583,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_config_base_derive"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2576,8 +2596,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_crypto"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "aead",
  "arrayref",
@@ -2612,8 +2632,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_data_model"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "base64",
  "derive-where",
@@ -2637,8 +2657,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_data_model_derive"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2650,8 +2670,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_derive"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2663,8 +2683,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_executor_data_model"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "derive_more 0.99.19",
  "iroha_data_model",
@@ -2676,8 +2696,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_executor_data_model_derive"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "manyhow",
  "proc-macro2",
@@ -2687,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_explorer"
-version = "0.3.0"
+version = "0.1.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -2696,6 +2716,7 @@ dependencies = [
  "chrono",
  "circular-buffer",
  "clap",
+ "const-str",
  "derive_more 2.0.1",
  "expect-test",
  "eyre",
@@ -2719,12 +2740,13 @@ dependencies = [
  "url",
  "utoipa",
  "utoipa-scalar",
+ "vergen",
 ]
 
 [[package]]
 name = "iroha_futures"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "iroha_config",
  "iroha_futures_derive",
@@ -2739,8 +2761,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_futures_derive"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -2751,8 +2773,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_logger"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "color-eyre",
  "derive_more 0.99.19",
@@ -2770,16 +2792,16 @@ dependencies = [
 
 [[package]]
 name = "iroha_macro"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "iroha_derive",
 ]
 
 [[package]]
 name = "iroha_macro_utils"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "darling",
  "drop_bomb",
@@ -2791,8 +2813,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_numeric"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "derive_more 0.99.19",
  "displaydoc",
@@ -2806,8 +2828,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_primitives"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "derive_more 0.99.19",
  "displaydoc",
@@ -2827,8 +2849,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_primitives_derive"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "iroha_numeric",
  "manyhow",
@@ -2839,8 +2861,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_schema"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "iroha_schema_derive",
  "serde",
@@ -2848,8 +2870,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_schema_derive"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "darling",
  "iroha_macro_utils",
@@ -2861,8 +2883,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_telemetry"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2887,8 +2909,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_telemetry_derive"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "iroha_macro_utils",
  "manyhow",
@@ -2899,16 +2921,16 @@ dependencies = [
 
 [[package]]
 name = "iroha_torii_const"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "iroha_primitives",
 ]
 
 [[package]]
 name = "iroha_version"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "iroha_macro",
  "iroha_version_derive",
@@ -2920,8 +2942,8 @@ dependencies = [
 
 [[package]]
 name = "iroha_version_derive"
-version = "2.0.0-rc.1.0"
-source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=3f039a3f51fdb16207a481dd2bedb8d17df86186#3f039a3f51fdb16207a481dd2bedb8d17df86186"
+version = "2.0.0-rc.2.0"
+source = "git+https://github.com/hyperledger-iroha/iroha.git?rev=v2.0.0-rc.2.0#765e8b3ad6f9b6ed40f28e12b0ad88949d4d90dd"
 dependencies = [
  "darling",
  "manyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "iroha_explorer"
 description = "Backend API of Iroha 2 Explorer"
-version = "0.3.0"
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-iroha = { git = "https://github.com/hyperledger-iroha/iroha.git", rev = "3f039a3f51fdb16207a481dd2bedb8d17df86186" }
+iroha = { git = "https://github.com/hyperledger-iroha/iroha.git", rev = "v2.0.0-rc.2.0" }
 
 tracing = "0.1.32"
 tracing-subscriber = { version = "0.3.10", features = ["env-filter"] }
@@ -33,11 +33,14 @@ derive_more = { version = "2.0.1", features = ["display", "from_str"] }
 circular-buffer = "1.1.0"
 reqwest = { version = "0.12.15", features = ["json"] }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
+const-str = { version = "0.6", features = ["proc"] }
 
 [dev-dependencies]
 insta = { version = "1.42.2", features = ["json", "csv"] }
 expect-test = "1.5.0"
-iroha_crypto = { git = "https://github.com/hyperledger-iroha/iroha.git", rev = "3f039a3f51fdb16207a481dd2bedb8d17df86186", features = ["rand"] }
+iroha_crypto = { git = "https://github.com/hyperledger-iroha/iroha.git", rev = "v2.0.0-rc.2.0", features = ["rand"] }
 tokio = { version = "1", features = ["process"] }
 
+[build-dependencies]
+vergen = { version = "8.3.1", default-features = false, features = ["cargo"] }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Iroha 2 Explorer Backend
 
-This is a backend service for
+This is the backend service for
 the [Iroha 2 Block Explorer Web application](https://github.com/soramitsu/iroha2-block-explorer-web).
 It is written in Rust and provides a classic HTTP-API way to observe data
 in [Iroha 2](https://github.com/hyperledger/iroha).
@@ -35,23 +35,39 @@ Use `help` for detailed usage documentation. In short:
 
 - `serve` to run the server
 - `scan` to scan Iroha ones and save into a database (for troubleshooting)
-- pass `--torii-url`, `--account`, and `--account-private-key` options to configure connection to Iroha
+- pass `--torii-urls`, `--account`, and `--account-private-key` options to configure connection to Iroha
 
 For example:
 
 ```shell
 # via ENVs; also could be passed as CLI args
-export ACCOUNT=<account id>
-export ACCOUNT_PRIVATE_KEY=<acount private key>
-export TORII_URL=http://localhost:8080
+export IROHA_EXPLORER_ACCOUNT=<account id>
+export IROHA_EXPLORER_ACCOUNT_PRIVATE_KEY=<acount private key>
+
+# At least one URL is required, the rest are for telemetry gathering
+export IROHA_EXPLORER_TORII_URLS=http://localhost:8080,http://localhost:8081
 
 iroha_explorer serve --port 4123
 iroha_explorer scan ./scanned.sqlite
 ```
 
+### OpenAPI Documentation
+
 With the running server, open `/api/docs` path (e.g. `http://localhost:4123/api/docs`) for API documentation.
 
-To configure **logging**, use `RUST_LOG` env var. For example:
+### Telemetry
+
+Iroha Explorer supports gathering telemetry from multiple nodes. You have to provide API URLs (Torii URLs) of each peer for that:
+
+```shell
+iroha_explorer serve --torii-urls http://localhost:8080,http://localhost:8081,http://localhost:8082
+```
+
+The documentation of the telemetry endpoints is available in the OpenAPI Documentation.
+
+### Logging
+
+To configure logging, use `RUST_LOG` env var. For example:
 
 ```shell
 RUST_LOG=iroha_explorer=debug,sqlx=debug
@@ -65,7 +81,7 @@ test "$(curl -fsSL localhost:4000/api/health)" = "healthy" && echo OK || echo FA
 
 ### Serve with test data
 
-_Only available in debug builds._
+_Only available in `debug` builds._
 
 Serve test data without connecting to Iroha:
 
@@ -73,6 +89,21 @@ Serve test data without connecting to Iroha:
 cargo run -- serve-test
 ```
 
-> `/status` endpoint would not work in this case
+> Note: telemetry data will be unavailable in this case.
 
+## Compatibility and Versioning
 
+Iroha Explorer aims to support only the latest version of Iroha. Currently it is `v2.0.0-rc.2.x`.
+
+Iroha Explorer itself doesn't have any strict versioning _yet_, and it is not yet published on https://crates.io.
+
+<!-- TODO: include a tip to run `iroha_explorer --version` to see the compatible Iroha version -->
+
+For reference:
+
+| Iroha               | Iroha Explorer                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
+| `v2.0.0-rc.2.x`     | [`iroha-2.0.0-rc.2`](https://github.com/soramitsu/iroha2-block-explorer-backend/tree/iroha-2.0.0-rc.2) |
+| `v2.0.0-rc.1.x`[^1] | [`iroha-2.0.0-rc.1`](https://github.com/soramitsu/iroha2-block-explorer-backend/tree/iroha-2.0.0-rc.1) |
+
+[^1]: Iroha versions `rc.1.3` and `rc.1.4` are not compatible with Explorer because of accidental breaking changes introduced in Iroha itself. Use version `rc.1.5` or newer.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    vergen::EmitBuilder::builder()
+        .git_sha(true)
+        .cargo_features()
+        .emit()
+        .unwrap();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,16 @@ use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _
 use utoipa::OpenApi;
 use utoipa_scalar::{Scalar, Servable};
 
+const COMPATIBLE_IROHA_VERSION: &str = "v2.0.0-rc.2";
+const VERSION: &str = const_str::format!(
+    "version={} git_commit_sha={} iroha_compat={}",
+    env!("CARGO_PKG_VERSION"),
+    env!("VERGEN_GIT_SHA"),
+    COMPATIBLE_IROHA_VERSION,
+);
+
 #[derive(Debug, Parser)]
-#[clap(about = "Iroha 2 Explorer Backend", version, long_about = None)]
+#[clap(about = "Iroha 2 Explorer Backend", version = VERSION, long_about = None)]
 pub struct Args {
     #[command(subcommand)]
     pub command: Subcommand,


### PR DESCRIPTION
...and pin Iroha versions in `Cargo.toml` to `v2.0.0-rc.2.0`.

Closes #61
Closes #62