### PR TITLE
docs: update compat & versioning guide (+ bump `0.2.1`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "iroha_explorer"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iroha_explorer"
 description = "Backend API of Iroha 2 Explorer"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -95,15 +95,13 @@ cargo run -- serve-test
 
 Iroha Explorer aims to support only the latest version of Iroha. Currently it is `v2.0.0-rc.2.x`.
 
-Iroha Explorer itself doesn't have any strict versioning _yet_, and it is not yet published on https://crates.io.
-
 <!-- TODO: include a tip to run `iroha_explorer --version` to see the compatible Iroha version -->
 
 For reference:
 
-| Iroha               | Iroha Explorer                                                                                         |
-| ------------------- | ------------------------------------------------------------------------------------------------------ |
-| `v2.0.0-rc.2.x`     | [`iroha-2.0.0-rc.2`](https://github.com/soramitsu/iroha2-block-explorer-backend/tree/iroha-2.0.0-rc.2) |
-| `v2.0.0-rc.1.x`[^1] | [`iroha-2.0.0-rc.1`](https://github.com/soramitsu/iroha2-block-explorer-backend/tree/iroha-2.0.0-rc.1) |
+| Iroha               | Iroha Explorer Backend ([tags](https://github.com/soramitsu/iroha2-block-explorer-backend/tags)) | Iroha Explorer Web ([tags](https://github.com/soramitsu/iroha2-block-explorer-web/tags))                      |
+| ------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `v2.0.0-rc.2.x`     | `v0.2.x`                                                                                         | _WiP, partial support: [`develop`](https://github.com/soramitsu/iroha2-block-explorer-web/tree/74c2e43cd6c8)_ |
+| `v2.0.0-rc.1.x`[^1] | `v0.1.0`                                                                                         | `v0.1.0`                                                                                                      |
 
-[^1]: Iroha versions `rc.1.3` and `rc.1.4` are not compatible with Explorer because of accidental breaking changes introduced in Iroha itself. Use version `rc.1.5` or newer.
+[^1]: Iroha versions `rc.1.3` and `rc.1.4` are not compatible with Explorer because of accidental breaking changes introduced in Iroha itself. Use version `rc.1.5`.


### PR DESCRIPTION
Close #74 

The approach is to:

- Have separate SemVer for both backend and frontend
- Assign tags like `v0.2.0`
- Keep single source of truth in this repo's README. Link to it from the frontend repo (https://github.com/soramitsu/iroha2-block-explorer-web/pull/100) 

Additionally, I have manually set tags in both repos:

- https://github.com/soramitsu/iroha2-block-explorer-backend/releases/tag/v0.2.0
- https://github.com/soramitsu/iroha2-block-explorer-backend/releases/tag/v0.1.0
- https://github.com/soramitsu/iroha2-block-explorer-web/releases/tag/v0.1.0