### PR TITLE
refactor(repo): insert data in batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown 0.13.2",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "zeroize",
 ]
@@ -189,7 +189,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "digest",
- "itertools",
+ "itertools 0.10.5",
  "num-bigint",
  "num-traits",
  "paste",
@@ -2725,6 +2725,7 @@ dependencies = [
  "insta",
  "iroha",
  "iroha_crypto",
+ "itertools 0.14.0",
  "nonzero_ext",
  "parity-scale-codec",
  "reqwest",
@@ -2974,6 +2975,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ circular-buffer = "1.1.0"
 reqwest = { version = "0.12.15", features = ["json"] }
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 const-str = { version = "0.6", features = ["proc"] }
+itertools = "0.14.0"
 
 [dev-dependencies]
 insta = { version = "1.42.2", features = ["json", "csv"] }


### PR DESCRIPTION
Closes #67 

- Load everything from Iroha in batches - do not fetch all at once
- Split batches further into SQLite insertion batches - avoid "Too many SQL variables" issue
- Run database update loop on a separate thread